### PR TITLE
Improve 3D tank gauge with capacity-based percentages

### DIFF
--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -1,67 +1,55 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
+import { OrbitControls, Environment, ContactShadows } from '@react-three/drei';
 import { Mesh } from 'three';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
+import { heightCapacityData } from "@/components/TankGauge";
 
 interface Tank3DProps {
-  heightPercentage: number;
+  heightPercentage: number; // capacity percentage
   onHeightChange: (height: number) => void;
   onCapacityChange: (capacity: number) => void;
 }
 
-// Volume correction factors table
-const volumeCorrectionFactors = {
-  densities: [0.500, 0.510, 0.520, 0.530, 0.540, 0.550, 0.560, 0.570, 0.580, 0.590],
-  temperatures: Array.from({length: 61}, (_, i) => i * 0.5), // 0 to 30 in 0.5 increments
-  factors: [
-    // Temperature 0.0°C
-    [1.070, 1.065, 1.060, 1.059, 1.056, 1.051, 1.050, 1.047, 1.046, 1.042],
-    // Temperature 0.5°C
-    [1.068, 1.063, 1.059, 1.058, 1.054, 1.050, 1.049, 1.045, 1.045, 1.041],
-    // ... continuing with the full table
-    // Temperature 20.0°C (baseline)
-    [1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000, 1.000],
-    // ... continuing to 30.0°C
-    [0.969, 0.970, 0.972, 0.973, 0.974, 0.976, 0.977, 0.978, 0.978, 0.980],
-  ]
-};
-
-// Tank data from height to capacity (using the provided extensive data)
-const tankData: [number, number][] = [
-  [0, 202], [46, 743], [92, 1284], [138, 2090], [184, 2953], [230, 3960],
-  [276, 5045], [322, 6212], [368, 7470], [414, 8773], [460, 10174], [506, 11593],
-  [552, 13115], [598, 14638], [644, 16257], [690, 17882], [736, 19574], [782, 21284],
-  [828, 23039], [874, 24821], [920, 26630], [966, 28473], [1012, 30327], [1058, 32218],
-  [1104, 34112], [1150, 36041], [1196, 37968], [1242, 39922], [1288, 41878], [1334, 43847],
-  [1380, 45820], [1426, 47797], [1472, 49777], [1518, 51756], [1564, 53733], [1610, 55707],
-  [1656, 57671], [1703, 59677], [1749, 61618], [1795, 63558], [1841, 65470], [1887, 67377],
-  [1933, 69251], [1979, 71113], [2025, 72945], [2071, 74749], [2117, 76530], [2163, 78266],
-  [2209, 79987], [2255, 81642], [2301, 83294], [2347, 84850], [2393, 86406], [2439, 87865],
-  [2485, 89305], [2531, 90652], [2577, 91954], [2623, 93173], [2669, 94308], [2715, 95375],
-  [2761, 96299], [2807, 97180], [2853, 97808], [2899, 98437], [2946, 98676], [2954, 98716]
-];
+const heightCapacityArray = Object.entries(heightCapacityData)
+  .map(([h, c]) => [Number(h), c] as [number, number])
+  .sort((a, b) => a[0] - b[0]);
+const maxHeight = heightCapacityArray[heightCapacityArray.length - 1][0];
+const maxCapacity = heightCapacityArray[heightCapacityArray.length - 1][1];
 
 const getCapacityFromHeight = (heightMm: number): number => {
-  if (heightMm <= 0) return tankData[0][1];
-  if (heightMm >= 2954) return tankData[tankData.length - 1][1];
-  
-  // Find the two closest points and interpolate
-  for (let i = 0; i < tankData.length - 1; i++) {
-    const [h1, c1] = tankData[i];
-    const [h2, c2] = tankData[i + 1];
-    
-    if (heightMm >= h1 && heightMm <= h2) {
-      const ratio = (heightMm - h1) / (h2 - h1);
-      return c1 + (c2 - c1) * ratio;
-    }
-  }
-  
-  return tankData[tankData.length - 1][1];
+  if (heightMm <= 0) return heightCapacityArray[0][1];
+  if (heightMm >= maxHeight) return maxCapacity;
+  const lower = Math.floor(heightMm);
+  const upper = Math.ceil(heightMm);
+  const c1 = heightCapacityData[lower];
+  const c2 = heightCapacityData[upper];
+  const ratio = (heightMm - lower) / (upper - lower);
+  return c1 + (c2 - c1) * ratio;
 };
 
-const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
+const getHeightFromCapacity = (capacity: number): number => {
+  if (capacity <= heightCapacityArray[0][1]) return heightCapacityArray[0][0];
+  if (capacity >= maxCapacity) return maxHeight;
+  for (let i = 0; i < heightCapacityArray.length - 1; i++) {
+    const [h1, c1] = heightCapacityArray[i];
+    const [h2, c2] = heightCapacityArray[i + 1];
+    if (capacity >= c1 && capacity <= c2) {
+      const ratio = (capacity - c1) / (c2 - c1);
+      return h1 + (h2 - h1) * ratio;
+    }
+  }
+  return maxHeight;
+};
+
+const keyLevels = [5, 10, 85, 90, 95].map(level => {
+  const capacity = (level / 100) * maxCapacity;
+  const height = getHeightFromCapacity(capacity);
+  return { level, height, percent: height / maxHeight };
+});
+
+const TankMesh = ({ fillLevel, activeLevel }: { fillLevel: number; activeLevel: number }) => {
   const tankRef = useRef<Mesh>(null);
   const liquidRef = useRef<Mesh>(null);
 
@@ -77,64 +65,60 @@ const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
 
   return (
     <group>
+      {/* Base platform */}
+      <mesh position={[0, -tankHeight / 2 - 0.05, 0]}>
+        <cylinderGeometry args={[tankRadius * 1.2, tankRadius * 1.2, 0.1, 64]} />
+        <meshStandardMaterial color="#374151" metalness={0.6} roughness={0.4} />
+      </mesh>
+
       {/* Tank body */}
       <mesh ref={tankRef} position={[0, 0, 0]}>
-        <cylinderGeometry args={[tankRadius, tankRadius, tankHeight, 32]} />
-        <meshStandardMaterial 
-          color="#e5e7eb" 
-          transparent 
-          opacity={0.3}
-          wireframe={false}
-        />
-      </mesh>
-      
-      {/* Tank walls */}
-      <mesh position={[0, 0, 0]}>
-        <cylinderGeometry args={[tankRadius, tankRadius, tankHeight, 32]} />
-        <meshStandardMaterial 
-          color="#6b7280" 
-          transparent 
-          opacity={0.1}
-          wireframe
+        <cylinderGeometry args={[tankRadius, tankRadius, tankHeight, 64]} />
+        <meshPhysicalMaterial
+          color="#d1d5db"
+          metalness={0.6}
+          roughness={0.2}
+          transmission={0.2}
+          clearcoat={1}
+          clearcoatRoughness={0.1}
         />
       </mesh>
 
       {/* Liquid inside */}
-      <mesh ref={liquidRef} position={[0, -tankHeight/2 + liquidHeight/2, 0]}>
-        <cylinderGeometry args={[tankRadius * 0.95, tankRadius * 0.95, liquidHeight, 32]} />
-        <meshStandardMaterial 
-          color="#22c55e" 
-          transparent 
+      <mesh ref={liquidRef} position={[0, -tankHeight / 2 + liquidHeight / 2, 0]}>
+        <cylinderGeometry args={[tankRadius * 0.95, tankRadius * 0.95, liquidHeight, 64]} />
+        <meshPhysicalMaterial
+          color="#065f46"
+          emissive="#064e3b"
+          emissiveIntensity={0.2}
+          metalness={0}
+          roughness={0.1}
+          transparent
           opacity={0.7}
+          transmission={0.9}
         />
       </mesh>
 
       {/* Level indicators */}
-      {[5, 10, 85, 90, 95].map(level => {
-        const indicatorHeight = (level / 100) * tankHeight - tankHeight/2;
+      {keyLevels.map(({ level, percent }) => {
+        const indicatorHeight = percent * tankHeight - tankHeight / 2;
         return (
           <mesh key={level} position={[tankRadius + 0.1, indicatorHeight, 0]}>
             <boxGeometry args={[0.2, 0.05, 0.05]} />
-            <meshStandardMaterial color={level === Math.round(fillLevel) ? "#15803d" : "#16a34a"} />
+            <meshStandardMaterial color={level === Math.round(activeLevel) ? "#064e3b" : "#065f46"} />
           </mesh>
         );
       })}
 
       {/* Level text markers */}
       <group>
-        {[
-          { level: 5, height: 121.1 },
-          { level: 10, height: 242.2 },
-          { level: 85, height: 2058.7 },
-          { level: 90, height: 2179.8 },
-          { level: 95, height: 2300.9 }
-        ].map(({ level, height }) => {
-          const indicatorHeight = (level / 100) * tankHeight - tankHeight/2;
+        {keyLevels.map(({ level, percent }) => {
+          const indicatorHeight = percent * tankHeight - tankHeight / 2;
           return (
             <mesh key={`text-${level}`} position={[tankRadius + 0.3, indicatorHeight, 0]}>
               <boxGeometry args={[0.1, 0.1, 0.01]} />
-              <meshStandardMaterial 
-                color={level === Math.round(fillLevel) ? "#15803d" : "#16a34a"}
+              <meshStandardMaterial
+                color={level === Math.round(activeLevel) ? "#064e3b" : "#065f46"}
                 transparent
                 opacity={0.8}
               />
@@ -147,21 +131,17 @@ const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
 };
 
 const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange }: Tank3DProps) => {
-  const [showVCF, setShowVCF] = useState(false);
-
   const handleSliderChange = (value: number[]) => {
     const newPercentage = value[0];
     onHeightChange(newPercentage);
-    
-    // Calculate height in mm based on percentage
-    const heightMm = (newPercentage / 100) * 2954; // Max height from data
-    const capacity = getCapacityFromHeight(heightMm);
+    const capacity = (newPercentage / 100) * maxCapacity;
     onCapacityChange(capacity);
   };
 
   // Calculate current height and capacity
-  const currentHeightMm = (heightPercentage / 100) * 2954;
-  const currentCapacity = getCapacityFromHeight(currentHeightMm);
+  const currentCapacity = (heightPercentage / 100) * maxCapacity;
+  const currentHeightMm = getHeightFromCapacity(currentCapacity);
+  const fillHeightPercent = (currentHeightMm / maxHeight) * 100;
 
   return (
     <Card>
@@ -173,11 +153,12 @@ const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange }: Tan
         <div className="h-80 w-full border rounded-lg bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900">
           <Canvas camera={{ position: [3, 2, 5], fov: 60 }}>
             <ambientLight intensity={0.5} />
-            <pointLight position={[10, 10, 10]} intensity={1} />
-            <directionalLight position={[0, 10, 0]} intensity={0.5} />
-            <TankMesh fillLevel={heightPercentage} />
-            <OrbitControls enablePan={false} enableZoom={true} />
-            <gridHelper args={[6, 10, "#666", "#666"]} />
+            <directionalLight position={[5, 5, 5]} intensity={0.8} />
+            <pointLight position={[0, 5, 0]} intensity={0.5} />
+            <TankMesh fillLevel={fillHeightPercent} activeLevel={heightPercentage} />
+            <OrbitControls enablePan={false} enableZoom />
+            <Environment preset="city" />
+            <ContactShadows position={[0, -3, 0]} opacity={0.25} scale={10} blur={2} far={10} />
           </Canvas>
         </div>
 
@@ -213,8 +194,18 @@ const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange }: Tan
           {/* Key level markers */}
           <div className="text-xs text-muted-foreground space-y-1">
             <div className="font-medium">Key Levels:</div>
-            <div>5% → 121.1 mm | 10% → 242.2 mm</div>
-            <div>85% → 2058.7 mm | 90% → 2179.8 mm | 95% → 2300.9 mm</div>
+            <div>
+              {keyLevels
+                .slice(0, 2)
+                .map(k => `${k.level}% → ${k.height.toFixed(1)} mm`)
+                .join(' | ')}
+            </div>
+            <div>
+              {keyLevels
+                .slice(2)
+                .map(k => `${k.level}% → ${k.height.toFixed(1)} mm`)
+                .join(' | ')}
+            </div>
           </div>
         </div>
       </CardContent>

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -4,7 +4,7 @@ import { Slider } from '@/components/ui/slider';
 
 // Height to capacity mapping based on tank measurements
 // Heights in MM mapped to capacities in L - Total Energies Uganda Tank Data
-const heightCapacityData: { [key: number]: number } = {
+export const heightCapacityData: { [key: number]: number } = {
   0: 202, 1: 214, 2: 226, 3: 237, 4: 249, 5: 261, 6: 273, 7: 285, 8: 296, 9: 308,
   10: 319, 11: 331, 12: 343, 13: 354, 14: 366, 15: 378, 16: 390, 17: 402, 18: 413, 19: 425,
   20: 437, 21: 449, 22: 461, 23: 472, 24: 484, 25: 496, 26: 508, 27: 520, 28: 531, 29: 543,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Refresh 3D tank gauge with metallic platform, additional lighting, and darker green liquid for a more appealing look
- Add typed calculation results and clean up imports to satisfy lint rules
- Replace empty interface declarations with type aliases and convert Tailwind plugin to ES module import

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ee57660408330963b6c8ed5fb300c