### PR TITLE
Add calibration info modal

### DIFF
--- a/src/components/AboutCalibrationDialog.tsx
+++ b/src/components/AboutCalibrationDialog.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+const specs = [
+  { label: "Tank", value: "Tank 01" },
+  { label: "Tank Owner", value: "Total Energies Uganda" },
+  { label: "Location", value: "Jinja, Uganda" },
+  { label: "Tank Description", value: "LPG Bullet Tank" },
+  { label: "Nominal Diameter", value: "2955 mm" },
+  { label: "Cylinder Length", value: "15000 mm" },
+  { label: "Tank Nominal Capacity", value: "98695 Liters" },
+  { label: "Date of Calibration", value: "27/06/2025" },
+  { label: "Validity", value: "10 Years" },
+  { label: "Overall Uncertainty", value: "+0.013%" },
+  { label: "Method of Calibration", value: "API MPMS CHAPTER 2" },
+  { label: "Tank calibrated by", value: "Murban Engineering Limited" },
+  { label: "Certificate No.", value: "20257001028TC-01" },
+];
+
+const AboutCalibrationDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">
+          About / Calibration
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Tank Calibration Details</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2">
+          {specs.map((item) => (
+            <div key={item.label} className="flex justify-between text-sm">
+              <span className="text-muted-foreground">{item.label}</span>
+              <span className="font-medium">{item.value}</span>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AboutCalibrationDialog;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import AboutCalibrationDialog from "./AboutCalibrationDialog";
 
 const Header = () => {
   return (
@@ -14,7 +15,7 @@ const Header = () => {
         </div>
         <div className="flex items-center gap-4">
           <Button variant="ghost" size="sm">Help</Button>
-          <Button variant="ghost" size="sm">About / Calibration</Button>
+          <AboutCalibrationDialog />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add AboutCalibrationDialog to show tank calibration details
- hook header's About / Calibration button to open modal

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bfc72fdc8330aca978479d112579