### PR TITLE
feat: add help dialog with contact details

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,11 @@
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 const Header = () => {
   return (
@@ -13,7 +20,44 @@ const Header = () => {
           <span className="font-semibold text-foreground">Total Energies Uganda</span>
         </div>
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm">Help</Button>
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="ghost" size="sm">Help</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Contact Information</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-2">
+                <p>
+                  <strong>Address:</strong> Tudor, Tom Mboya, P.O. BOX 99215-80100,
+                  Mombasa Kenya
+                </p>
+                <p>
+                  <strong>City/Town:</strong> Mombasa
+                </p>
+                <p>
+                  <strong>Telephone Number:</strong> + 254 20 265 0617/8
+                </p>
+                <p>
+                  <strong>Email Address:</strong> info@murban-eng.com
+                </p>
+                <p>
+                  <strong>Website:</strong>{" "}
+                  <a
+                    href="https://murban-eng.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    https://murban-eng.com/
+                  </a>
+                </p>
+                <p>
+                  <strong>Category:</strong> Engineers and Engineering Firms
+                </p>
+              </div>
+            </DialogContent>
+          </Dialog>
           <Button variant="ghost" size="sm">About / Calibration</Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show company contact details when Help button clicked

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 4 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a6c08b4b50833097bbcf40a40bfcba