### PR TITLE
Add help dialog with Murban engineering contact details

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/ui/button";
 import AboutCalibrationDialog from "./AboutCalibrationDialog";
+import HelpDialog from "./HelpDialog";
 
 const Header = () => {
   return (
@@ -14,7 +14,7 @@ const Header = () => {
           <span className="font-semibold text-foreground">Total Energies Uganda</span>
         </div>
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm">Help</Button>
+          <HelpDialog />
           <AboutCalibrationDialog />
         </div>
       </div>

--- a/src/components/HelpDialog.tsx
+++ b/src/components/HelpDialog.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+const info = [
+  {
+    label: "Address",
+    value: "Tudor, Tom Mboya, P.O. BOX 99215-80100, Mombasa Kenya",
+  },
+  { label: "City/Town", value: "Mombasa" },
+  { label: "Telephone Number", value: "+ 254 20 265 0617/8" },
+  { label: "Email Address", value: "info@murban-eng.com" },
+  { label: "Website", value: "https://murban-eng.com/" },
+  { label: "Category", value: "Engineers and Engineering Firms" },
+];
+
+const HelpDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">
+          Help
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Murban engineering</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2">
+          {info.map((item) => (
+            <div key={item.label} className="flex justify-between text-sm">
+              <span className="text-muted-foreground">{item.label}</span>
+              {item.label === "Website" ? (
+                <a
+                  href={item.value}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-primary hover:underline"
+                >
+                  {item.value}
+                </a>
+              ) : (
+                <span className="font-medium">{item.value}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default HelpDialog;
+


### PR DESCRIPTION
## Summary
- add Help dialog component displaying Murban engineering contact info
- wire Help dialog into Header replacing placeholder Help button

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c2053f888330b93a7e1ea4f7f724