### PR TITLE
Add Tank view page for Uganda tank image

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import TankView from "./pages/TankView";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/tank-view" element={<TankView />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import AboutCalibrationDialog from "./AboutCalibrationDialog";
 import HelpDialog from "./HelpDialog";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   return (
@@ -14,6 +15,9 @@ const Header = () => {
           <span className="font-semibold text-foreground">Total Energies Uganda</span>
         </div>
         <div className="flex items-center gap-4">
+          <Link to="/tank-view" className="text-sm font-medium text-foreground hover:text-primary">
+            Tank view
+          </Link>
           <HelpDialog />
           <AboutCalibrationDialog />
         </div>

--- a/src/pages/TankView.tsx
+++ b/src/pages/TankView.tsx
@@ -1,0 +1,19 @@
+import Header from "@/components/Header";
+
+const TankView = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="max-w-7xl mx-auto px-6 py-8">
+        <h1 className="text-3xl font-bold text-foreground mb-4">Tank view</h1>
+        <img
+          src="/uganda%20tank%201.jpg"
+          alt="Tank view"
+          className="w-full rounded-lg"
+        />
+      </main>
+    </div>
+  );
+};
+
+export default TankView;


### PR DESCRIPTION
## Summary
- add Tank view page displaying Uganda tank 1 image
- link Tank view page from header and configure routing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: An interface declaring no members and forbidden require style import)
- `npx eslint src/App.tsx src/components/Header.tsx src/pages/TankView.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6c8561f5c833086da64c4b1a9ccf2