### PR TITLE
chore: lighten tank gauge colors

### DIFF
--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -109,9 +109,9 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
       {fillLevel > 0 && (
         <mesh ref={liquidRef} position={[0, -tankRadius + liquidHeight/2, 0]}>
           <boxGeometry args={[tankLength, liquidHeight, tankRadius * 1.8]} />
-          <meshStandardMaterial 
-            color="hsl(var(--primary))" 
-            transparent 
+          <meshStandardMaterial
+            color="#bbf7d0"
+            transparent
             opacity={0.6}
           />
         </mesh>
@@ -124,14 +124,14 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
           <group key={level}>
             <mesh position={[-tankLength/2 - 0.2, indicatorY, 0]}>
               <boxGeometry args={[0.3, 0.05, 0.05]} />
-              <meshStandardMaterial 
-                color={Math.abs(level - fillLevel) < 5 ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))"} 
+              <meshStandardMaterial
+                color={Math.abs(level - fillLevel) < 5 ? "#4ade80" : "hsl(var(--muted-foreground))"}
               />
             </mesh>
             <mesh position={[tankLength/2 + 0.2, indicatorY, 0]}>
               <boxGeometry args={[0.3, 0.05, 0.05]} />
-              <meshStandardMaterial 
-                color={Math.abs(level - fillLevel) < 5 ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))"} 
+              <meshStandardMaterial
+                color={Math.abs(level - fillLevel) < 5 ? "#4ade80" : "hsl(var(--muted-foreground))"}
               />
             </mesh>
           </group>
@@ -144,8 +144,8 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         return (
           <mesh key={`text-${level}`} position={[-tankLength/2 - 0.5, indicatorY, 0]}>
             <boxGeometry args={[0.1, 0.1, 0.01]} />
-            <meshStandardMaterial 
-              color={Math.abs(level - fillLevel) < 5 ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))"}
+            <meshStandardMaterial
+              color={Math.abs(level - fillLevel) < 5 ? "#4ade80" : "hsl(var(--muted-foreground))"}
               transparent
               opacity={0.8}
             />

--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -102,9 +102,9 @@ const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
       {/* Liquid inside */}
       <mesh ref={liquidRef} position={[0, -tankHeight/2 + liquidHeight/2, 0]}>
         <cylinderGeometry args={[tankRadius * 0.95, tankRadius * 0.95, liquidHeight, 32]} />
-        <meshStandardMaterial 
-          color="#22c55e" 
-          transparent 
+        <meshStandardMaterial
+          color="#bbf7d0"
+          transparent
           opacity={0.7}
         />
       </mesh>
@@ -115,7 +115,7 @@ const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
         return (
           <mesh key={level} position={[tankRadius + 0.1, indicatorHeight, 0]}>
             <boxGeometry args={[0.2, 0.05, 0.05]} />
-            <meshStandardMaterial color={level === Math.round(fillLevel) ? "#15803d" : "#16a34a"} />
+            <meshStandardMaterial color={level === Math.round(fillLevel) ? "#4ade80" : "#86efac"} />
           </mesh>
         );
       })}
@@ -133,8 +133,8 @@ const TankMesh = ({ fillLevel }: { fillLevel: number }) => {
           return (
             <mesh key={`text-${level}`} position={[tankRadius + 0.3, indicatorHeight, 0]}>
               <boxGeometry args={[0.1, 0.1, 0.01]} />
-              <meshStandardMaterial 
-                color={level === Math.round(fillLevel) ? "#15803d" : "#16a34a"}
+              <meshStandardMaterial
+                color={level === Math.round(fillLevel) ? "#4ade80" : "#86efac"}
                 transparent
                 opacity={0.8}
               />

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -337,10 +337,10 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, onHeightChange,
         <div className="flex justify-center">
           <div className="relative">
             {/* Tank Outline */}
-            <div className="w-32 h-64 border-4 border-primary rounded-lg bg-secondary/20 relative overflow-hidden">
+            <div className="w-32 h-64 border-4 border-green-500 rounded-lg bg-secondary/20 relative overflow-hidden">
               {/* Liquid Level */}
-              <div 
-                className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-primary to-primary/70 transition-all duration-300 ease-out"
+              <div
+                className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-green-400 to-green-200 transition-all duration-300 ease-out"
                 style={{ height: `${heightPercentage}%` }}
               />
               {/* Percentage Labels */}


### PR DESCRIPTION
## Summary
- update tank gauge to use light green fill and border
- adjust 3D tank meshes and markers to light green tones

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 12 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cd4a45c88330ac9bff748f6b7d60