### PR TITLE
Ensure Uganda tank image displays in tank view

### DIFF
--- a/src/pages/TankView.tsx
+++ b/src/pages/TankView.tsx
@@ -7,7 +7,7 @@ const TankView = () => {
       <main className="max-w-7xl mx-auto px-6 py-8">
         <h1 className="text-3xl font-bold text-foreground mb-4">Tank view</h1>
         <img
-          src="/uganda%20tank%201.jpg"
+          src={`${import.meta.env.BASE_URL}uganda%20tank%201.jpg`}
           alt="Tank view"
           className="w-full rounded-lg"
         />


### PR DESCRIPTION
## Summary
- fix tank view to prefix uganda tank image with Vite base URL and encode spaces so it always loads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden and other lint errors in existing files)*
- `npx eslint src/pages/TankView.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6cb4ecdf48330b521ef8b8b5a37f3