### PR TITLE
Render tank gauge as cylindrical cross-section

### DIFF
--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -337,7 +337,7 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, onHeightChange,
         <div className="flex justify-center">
           <div className="relative">
             {/* Tank Outline */}
-            <div className="w-32 h-64 border-4 border-green-500 rounded-lg bg-secondary/20 relative overflow-hidden">
+            <div className="w-64 h-64 border-4 border-green-500 rounded-full bg-secondary/20 relative overflow-hidden">
               {/* Liquid Level */}
               <div
                 className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-green-400 to-green-200 transition-all duration-300 ease-out"


### PR DESCRIPTION
## Summary
- Display tank gauge using a circular outline to mimic a cylindrical tank
- Liquid fill now rises within the circular boundary instead of a rectangle

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type in src/components/ui/textarea.tsx; A `require()` style import is forbidden @typescript-eslint/no-require-imports in tailwind.config.ts)*
- `npx eslint src/components/TankGauge.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a6df06127483308423fbf19030d09f