### PR TITLE
Fix liquid fill direction in 3D tank gauge

### DIFF
--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -43,10 +43,12 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
   const tankLength = 8;
   const tankRadius = 1.2;
   const hemisphereRadius = tankRadius;
-  
+
   // Calculate liquid geometry for horizontal tank - fill from bottom up
   const liquidHeight = (fillLevel / 100) * (tankRadius * 2);
-  const clipPlane = new Plane(new Vector3(0, 1, 0), tankRadius - liquidHeight);
+  // Move a clipping plane from the bottom (-tankRadius) to the top (+tankRadius)
+  // so that increasing the fill level reveals more liquid from the bottom up.
+  const clipPlane = new Plane(new Vector3(0, -1, 0), -tankRadius + liquidHeight);
 
   return (
     <group>


### PR DESCRIPTION
## Summary
- ensure 3D tank's liquid fill originates at bottom and rises with percentage

## Testing
- `npm run lint` (fails: no-empty-object-type, no-require-imports)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e2c722b883309ff3a8beafb753a0