### PR TITLE
Ensure full logo is visible

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => {
           <img
             src="/murbanlogo.jpg"
             alt="Murban logo"
-            className="w-8 h-8 object-cover rounded"
+            className="w-8 h-8 object-contain"
           />
           <span className="font-semibold text-foreground">Total Energies Uganda</span>
         </div>


### PR DESCRIPTION
## Summary
- use `object-contain` for Murban logo so the entire image is visible

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 4 errors, 8 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a6f45a3e7483308dc0237f80f86ab6