### PR TITLE
fix: display tank image on tank view

### DIFF
--- a/src/pages/TankView.tsx
+++ b/src/pages/TankView.tsx
@@ -8,7 +8,7 @@ const TankView = () => {
         <h1 className="text-3xl font-bold text-foreground mb-4">Tank view</h1>
         <div className="relative">
           <img
-            src={encodeURI("/uganda tank1.jpg")}
+            src="/tank1.jpg"
             alt="Tank view"
             className="w-full rounded-lg"
           />


### PR DESCRIPTION
## Summary
- use `tank1.jpg` in TankView page to render tank image from public directory

## Testing
- `npm run lint` *(fails: unexpected any, no-empty-object-type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a701f90cfc8330ae6b0dc9707220db