### PR TITLE
Rearrange header layout for more space

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,12 +14,14 @@ const Header = () => {
           />
           <span className="font-semibold text-foreground">Total Energies Uganda</span>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex items-center gap-4">
+            <AboutCalibrationDialog />
+            <HelpDialog />
+          </div>
           <Link to="/tank-view" className="text-sm font-medium text-foreground hover:text-primary">
             Tank view
           </Link>
-          <HelpDialog />
-          <AboutCalibrationDialog />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Move Tank View link below About Calibration button to free up header space

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 4 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a705df27b483308df20ee3041b83a1