### PR TITLE
feat: show tank gauge first on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,22 +6,16 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      <main className="max-w-7xl mx-auto px-6 py-8">
-        <div className="mb-8">
+      <main className="max-w-7xl mx-auto px-6 py-8 space-y-8">
+        <CalculatorForm />
+
+        <div>
           <h1 className="text-3xl font-bold text-foreground mb-2">Total Energies Uganda</h1>
           <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
           <p className="text-muted-foreground">Tank 01 — LPG Bullet Tank (Jinja, Uganda)</p>
-          <img
-            src={encodeURI("/uganda tank1.jpg")}
-            alt="Uganda tank"
-            className="mt-4 w-full rounded-lg"
-          />
         </div>
-        
-        <div className="space-y-8">
-          <CalculatorForm />
-          <TankDescription />
-        </div>
+
+        <TankDescription />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- Show tank gauge at the top of the home page
- Remove placeholder tank image from home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)
- `npx eslint src/pages/Index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a7067df5a48330a44f1179d1888015