### PR TITLE
chore: remove front page placeholder image

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,11 +11,6 @@ const Index = () => {
           <h1 className="text-3xl font-bold text-foreground mb-2">Total Energies Uganda</h1>
           <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
           <p className="text-muted-foreground">Tank 01 — LPG Bullet Tank (Jinja, Uganda)</p>
-          <img
-            src={encodeURI("/uganda tank1.jpg")}
-            alt="Uganda tank"
-            className="mt-4 w-full rounded-lg"
-          />
         </div>
         
         <div className="space-y-8">


### PR DESCRIPTION
## Summary
- Remove Uganda tank placeholder image from landing page so the 3D gauge is the first visible element

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a708de2acc8330b1d644c0c61e5ee3