### PR TITLE
feat: add Total energies Uganda header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,13 +6,13 @@ const Header = () => {
   return (
     <header className="bg-card border-b border-border px-6 py-4">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <div className="flex flex-col items-center gap-1">
           <img
             src="/murbanlogo.jpg"
             alt="Murban logo"
             className="w-16 h-16 object-contain rounded"
           />
-          <span className="font-semibold text-foreground">TotalEnergies</span>
+          <span className="font-bold text-foreground">Total energies uganda</span>
         </div>
         <div className="flex flex-col items-end gap-2">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- add bold Total energies uganda title beneath Murban logo

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: A `require()` style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a70936a9cc8330986baf8075a1383a