### PR TITLE
Remove wireframe cylinder from horizontal tank gauge

### DIFF
--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -83,18 +83,8 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         />
       </mesh>
 
-      {/* Tank outline wireframe */}
-      <mesh position={[0, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
-        <cylinderGeometry args={[tankRadius, tankRadius, tankLength, 32]} />
-        <meshStandardMaterial
-          color="hsl(var(--border))"
-          transparent
-          opacity={0.4}
-          wireframe
-        />
-      </mesh>
-
-      {/* Support bars at edges */}
+        {/* Wireframe removed to avoid crisscrossed appearance */}
+        {/* Support bars at edges */}
       {[-tankLength / 2, tankLength / 2].map((x, idx) => (
         <mesh key={`support-${idx}`} position={[x, -tankRadius - 0.4, 0]}>
           <boxGeometry args={[0.2, 0.8, 0.2]} />


### PR DESCRIPTION
## Summary
- remove wireframe cylinder that created crisscross lines in horizontal bullet tank 3D gauge

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a71032e5b8833092bd43e7f170da9c