### PR TITLE
Remove vertical wireframe from horizontal 3D gauge

### DIFF
--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -83,17 +83,6 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         />
       </mesh>
 
-      {/* Tank outline wireframe */}
-      <mesh position={[0, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
-        <cylinderGeometry args={[tankRadius, tankRadius, tankLength, 32]} />
-        <meshStandardMaterial
-          color="hsl(var(--border))"
-          transparent
-          opacity={0.4}
-          wireframe
-        />
-      </mesh>
-
       {/* Support bars at edges */}
       {[-tankLength / 2, tankLength / 2].map((x, idx) => (
         <mesh key={`support-${idx}`} position={[x, -tankRadius - 0.4, 0]}>


### PR DESCRIPTION
## Summary
- remove wireframe cylinder that created a vertical cross through the 3D horizontal tank gauge

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in ui/textarea, @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7130786c48330a93199a75f0ecec7