### PR TITLE
Add tank 02 description and dynamic selection

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -38,7 +38,22 @@ interface FormData {
   showVCFTable: boolean;
 }
 
-const CalculatorForm = () => {
+interface CalculatorFormProps {
+  selectedTank: 'tank1' | 'tank2';
+  onTankChange: (tank: 'tank1' | 'tank2') => void;
+}
+
+interface CalculationResults {
+  referenceVolume: number;
+  vcf: number;
+  scf: number;
+  correctedVolume: number;
+  pcf: number;
+  density: number;
+  mass: number;
+}
+
+const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => {
   const [formData, setFormData] = useState<FormData>({
     productDensity: "0.55",
     productTemperature: "20",
@@ -64,7 +79,7 @@ const CalculatorForm = () => {
     24: 1.000088,
   };
 
-  const [results, setResults] = useState<any>(null);
+  const [results, setResults] = useState<CalculationResults | string | null>(null);
   const [heightPercentage, setHeightPercentage] = useState<number>(0);
   const [capacity, setCapacity] = useState<number>(100);
   
@@ -176,6 +191,8 @@ const CalculatorForm = () => {
         heightPercentage={heightPercentage}
         onHeightChange={handleHeightChange}
         onCapacityChange={handleCapacityChange}
+        selectedTank={selectedTank}
+        onTankChange={onTankChange}
       />
       
       <Card>

--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { Mesh, Plane, Vector3 } from 'three';
@@ -11,6 +11,8 @@ interface HorizontalBulletTank3DProps {
   heightPercentage: number;
   onHeightChange: (height: number) => void;
   onCapacityChange: (capacity: number) => void;
+  selectedTank: 'tank1' | 'tank2';
+  onTankChange: (tank: 'tank1' | 'tank2') => void;
 }
 
 const getCapacityFromHeight = (heightMm: number): number => {
@@ -145,8 +147,13 @@ const BulletTankMesh = ({ fillLevel }: { fillLevel: number }) => {
   );
 };
 
-const HorizontalBulletTank3D = ({ heightPercentage, onHeightChange, onCapacityChange }: HorizontalBulletTank3DProps) => {
-  const [selectedTank, setSelectedTank] = useState("tank1");
+const HorizontalBulletTank3D = ({
+  heightPercentage,
+  onHeightChange,
+  onCapacityChange,
+  selectedTank,
+  onTankChange,
+}: HorizontalBulletTank3DProps) => {
 
   const handleSliderChange = (value: number[]) => {
     const newPercentage = value[0];
@@ -159,7 +166,7 @@ const HorizontalBulletTank3D = ({ heightPercentage, onHeightChange, onCapacityCh
   };
 
   const handleTankChange = (value: string) => {
-    if (value) setSelectedTank(value);
+    if (value) onTankChange(value);
   };
 
   // Calculate current height and capacity

--- a/src/components/TankDescription.tsx
+++ b/src/components/TankDescription.tsx
@@ -1,15 +1,32 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const TankDescription = () => {
-  const specifications = [
+interface TankDescriptionProps {
+  selectedTank: 'tank1' | 'tank2';
+}
+
+const tankSpecifications: Record<'tank1' | 'tank2', { label: string; value: string; label2?: string; value2?: string }[]> = {
+  tank1: [
     { label: "Tank", value: "Tank 01", label2: "Date of Calibration", value2: "27/06/2025" },
     { label: "Tank Owner", value: "Total Energies Uganda", label2: "Validity", value2: "10 Years" },
     { label: "Location", value: "Jinja, Uganda", label2: "Overall Uncertainty", value2: "+0.013%" },
     { label: "Tank Description", value: "LPG Bullet Tank", label2: "Method of Calibration", value2: "API MPMS CHAPTER 2" },
     { label: "Nominal Diameter", value: "2955 mm", label2: "Tank calibrated by", value2: "Murban Engineering Limited" },
     { label: "Cylinder Length", value: "15000 mm", label2: "Certificate No.", value2: "20257001028TC-01" },
-    { label: "Tank Nominal Capacity", value: "98695 Liters", label2: "", value2: "" },
-  ];
+    { label: "Tank Nominal Capacity", value: "98695 Liters" },
+  ],
+  tank2: [
+    { label: "Tank", value: "Tank 02", label2: "Date of Calibration", value2: "29/06/2025" },
+    { label: "Tank Owner", value: "Total Energies Jinja.", label2: "Validity", value2: "10 Years" },
+    { label: "Location", value: "Jinja, Uganda", label2: "Overall Uncertainty", value2: "+0.012%" },
+    { label: "Tank Description", value: "LPG Bullet Tank", label2: "Method of Calibration", value2: "API MPMS CHAPTER 2" },
+    { label: "Nominal Diameter", value: "2422 mm", label2: "Tank calibrated by", value2: "Murban Engineering Limited" },
+    { label: "Cylinder Length", value: "15000 mm", label2: "Certificate No.", value2: "20257001028TC-02" },
+    { label: "Tank Nominal Capacity", value: "98682 Liters" },
+  ],
+};
+
+const TankDescription = ({ selectedTank }: TankDescriptionProps) => {
+  const specifications = tankSpecifications[selectedTank];
 
   return (
     <Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,21 +1,33 @@
+import { useState } from "react";
 import Header from "@/components/Header";
 import CalculatorForm from "@/components/CalculatorForm";
 import TankDescription from "@/components/TankDescription";
 
 const Index = () => {
+  const [selectedTank, setSelectedTank] = useState<'tank1' | 'tank2'>('tank1');
+
   return (
     <div className="min-h-screen bg-background">
       <Header />
       <main className="max-w-7xl mx-auto px-6 py-8">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-foreground mb-2">Total Energies Uganda</h1>
+          <h1 className="text-3xl font-bold text-foreground mb-2">
+            {selectedTank === "tank1" ? "Total Energies Uganda" : "Total Energies Jinja."}
+          </h1>
           <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
-          <p className="text-muted-foreground">Tank 01 — LPG Bullet Tank (Jinja, Uganda)</p>
+          <p className="text-muted-foreground">
+            {selectedTank === "tank1"
+              ? "Tank 01 — LPG Bullet Tank (Jinja, Uganda)"
+              : "Tank 02 — LPG Bullet Tank (Jinja, Uganda)"}
+          </p>
         </div>
-        
+
         <div className="space-y-8">
-          <CalculatorForm />
-          <TankDescription />
+          <CalculatorForm
+            selectedTank={selectedTank}
+            onTankChange={setSelectedTank}
+          />
+          <TankDescription selectedTank={selectedTank} />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Make tank selection stateful across the calculator and description
- Add full specification details for Tank 02 and display when selected
- Update 3D gauge and description components to handle tank switching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, etc.)*
- `npx eslint src/components/CalculatorForm.tsx src/components/HorizontalBulletTank3D.tsx src/components/TankDescription.tsx src/pages/Index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a75e12d84c833081ca193a2707d5ee