### PR TITLE
Update tank 2 capacity chart and specs

### DIFF
--- a/src/components/AboutCalibrationDialog.tsx
+++ b/src/components/AboutCalibrationDialog.tsx
@@ -8,11 +8,11 @@ import {
 } from "@/components/ui/dialog";
 
 const specs = [
-  { label: "Tank", value: "Tank 01" },
+  { label: "Tank", value: "Tank 02" },
   { label: "Tank Owner", value: "Total Energies Uganda" },
   { label: "Location", value: "Jinja, Uganda" },
   { label: "Tank Description", value: "LPG Bullet Tank" },
-  { label: "Nominal Diameter", value: "2955 mm" },
+  { label: "Nominal Diameter", value: "2422 mm" },
   { label: "Cylinder Length", value: "15000 mm" },
   { label: "Tank Nominal Capacity", value: "98695 Liters" },
   { label: "Date of Calibration", value: "27/06/2025" },

--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -11,7 +11,7 @@ import { heightCapacityData } from "@/components/TankGauge";
 
 const getCapacityFromHeight = (heightMm: number): number => {
   if (heightMm <= 0) return heightCapacityData[0];
-  const maxHeight = 2954;
+  const maxHeight = 2422;
   if (heightMm >= maxHeight) return heightCapacityData[maxHeight];
 
   const lower = Math.floor(heightMm);
@@ -80,7 +80,7 @@ const CalculatorForm = () => {
     if (field === 'heightMm' && typeof value === 'string') {
       const heightMm = parseFloat(value);
       if (!isNaN(heightMm)) {
-        const percentage = (heightMm / 2955) * 100; // Convert mm to percentage
+        const percentage = (heightMm / 2422) * 100; // Convert mm to percentage
         setHeightPercentage(Math.min(100, Math.max(0, percentage)));
 
         // Also update capacity based on height using interpolation data
@@ -92,7 +92,7 @@ const CalculatorForm = () => {
   const handleHeightChange = (height: number) => {
     setHeightPercentage(height);
     // Auto-sync height in mm based on percentage
-    const heightMm = (height / 100) * 2955; // Max height from tank specifications
+    const heightMm = (height / 100) * 2422; // Max height from tank specifications
     setFormData(prev => ({ ...prev, heightMm: heightMm.toString() }));
   };
 

--- a/src/components/DataTableModals.tsx
+++ b/src/components/DataTableModals.tsx
@@ -171,7 +171,7 @@ const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapa
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
-                <strong>Tank:</strong> Tank 01
+                <strong>Tank:</strong> Tank 02
               </div>
               <div>
                 <strong>Tank Owner:</strong> Total Energies Uganda
@@ -183,7 +183,7 @@ const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapa
                 <strong>Tank Description:</strong> LPG Bullet Tank
               </div>
               <div>
-                <strong>Nominal Diameter:</strong> 2955 mm
+                <strong>Nominal Diameter:</strong> 2422 mm
               </div>
               <div>
                 <strong>Cylinder Length:</strong> 15000 mm

--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -15,7 +15,7 @@ interface HorizontalBulletTank3DProps {
 
 const getCapacityFromHeight = (heightMm: number): number => {
   if (heightMm <= 0) return heightCapacityData[0];
-  const maxHeight = 2954;
+  const maxHeight = 2422;
   if (heightMm >= maxHeight) return heightCapacityData[maxHeight];
 
   const lower = Math.floor(heightMm);
@@ -153,7 +153,7 @@ const HorizontalBulletTank3D = ({ heightPercentage, onHeightChange, onCapacityCh
     onHeightChange(newPercentage);
     
     // Calculate height in mm based on percentage
-    const heightMm = (newPercentage / 100) * 2955; // Max height from specifications
+    const heightMm = (newPercentage / 100) * 2422; // Max height from specifications
     const capacity = getCapacityFromHeight(heightMm);
     onCapacityChange(capacity);
   };
@@ -163,7 +163,7 @@ const HorizontalBulletTank3D = ({ heightPercentage, onHeightChange, onCapacityCh
   };
 
   // Calculate current height and capacity
-  const currentHeightMm = (heightPercentage / 100) * 2955;
+  const currentHeightMm = (heightPercentage / 100) * 2422;
   const currentCapacity = getCapacityFromHeight(currentHeightMm);
 
   return (
@@ -244,12 +244,12 @@ const HorizontalBulletTank3D = ({ heightPercentage, onHeightChange, onCapacityCh
           <div className="text-xs text-muted-foreground bg-muted/20 p-2 rounded">
             <div className="font-medium mb-1">Reference Levels:</div>
             <div className="grid grid-cols-2 gap-1">
-              <div>5% → 154.45 mm</div>
-              <div>10% → 308.90 mm</div>
-              <div>85% → 2625.65 mm</div>
-              <div>90% → 2780.1 mm</div>
-              <div>95% → 2934.55 mm</div>
-              <div>Max → 2955 mm</div>
+              <div>5% → 121.1 mm</div>
+              <div>10% → 242.2 mm</div>
+              <div>85% → 2058.7 mm</div>
+              <div>90% → 2179.8 mm</div>
+              <div>95% → 2300.9 mm</div>
+              <div>Max → 2422 mm</div>
             </div>
           </div>
         </div>

--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -154,13 +154,13 @@ const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange }: Tan
     onHeightChange(newPercentage);
     
     // Calculate height in mm based on percentage
-    const heightMm = (newPercentage / 100) * 2954; // Max height from data
+    const heightMm = (newPercentage / 100) * 2422; // Max height from data
     const capacity = getCapacityFromHeight(heightMm);
     onCapacityChange(capacity);
   };
 
   // Calculate current height and capacity
-  const currentHeightMm = (heightPercentage / 100) * 2954;
+  const currentHeightMm = (heightPercentage / 100) * 2422;
   const currentCapacity = getCapacityFromHeight(currentHeightMm);
 
   return (

--- a/src/components/TankDescription.tsx
+++ b/src/components/TankDescription.tsx
@@ -2,11 +2,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const TankDescription = () => {
   const specifications = [
-    { label: "Tank", value: "Tank 01", label2: "Date of Calibration", value2: "27/06/2025" },
+    { label: "Tank", value: "Tank 02", label2: "Date of Calibration", value2: "27/06/2025" },
     { label: "Tank Owner", value: "Total Energies Uganda", label2: "Validity", value2: "10 Years" },
     { label: "Location", value: "Jinja, Uganda", label2: "Overall Uncertainty", value2: "+0.013%" },
     { label: "Tank Description", value: "LPG Bullet Tank", label2: "Method of Calibration", value2: "API MPMS CHAPTER 2" },
-    { label: "Nominal Diameter", value: "2955 mm", label2: "Tank calibrated by", value2: "Murban Engineering Limited" },
+    { label: "Nominal Diameter", value: "2422 mm", label2: "Tank calibrated by", value2: "Murban Engineering Limited" },
     { label: "Cylinder Length", value: "15000 mm", label2: "Certificate No.", value2: "20257001028TC-01" },
     { label: "Tank Nominal Capacity", value: "98695 Liters", label2: "", value2: "" },
   ];
@@ -42,14 +42,14 @@ const TankDescription = () => {
             </p>
             <div className="grid grid-cols-2 gap-2 text-xs">
               <div className="space-y-1">
-                <div><strong>5%:</strong> 154.45 mm</div>
-                <div><strong>10%:</strong> 308.90 mm</div>
-                <div><strong>85%:</strong> 2625.65 mm</div>
+                <div><strong>5%:</strong> 121.1 mm</div>
+                <div><strong>10%:</strong> 242.2 mm</div>
+                <div><strong>85%:</strong> 2058.7 mm</div>
               </div>
               <div className="space-y-1">
-                <div><strong>90%:</strong> 2780.1 mm</div>
-                <div><strong>95%:</strong> 2934.55 mm</div>
-                <div><strong>Max:</strong> 2955 mm</div>
+                <div><strong>90%:</strong> 2179.8 mm</div>
+                <div><strong>95%:</strong> 2300.9 mm</div>
+                <div><strong>Max:</strong> 2422 mm</div>
               </div>
             </div>
           </div>

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -306,8 +306,8 @@ export const heightCapacityData: { [key: number]: number } = {
 
 // Convert height percentage (0-100) to millimeters and get capacity
 function getCapacityFromPercentage(percentage: number): number {
-  // Convert percentage to height in millimeters (0% = 0mm, 100% = 2954mm for full range)
-  const heightMM = Math.round((percentage / 100) * 2954);
+  // Convert percentage to height in millimeters (0% = 0mm, 100% = 2422mm for full range)
+  const heightMM = Math.round((percentage / 100) * 2422);
   return heightCapacityData[heightMM] || 202;
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,7 +10,7 @@ const Index = () => {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground mb-2">Total Energies Uganda</h1>
           <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
-          <p className="text-muted-foreground">Tank 01 — LPG Bullet Tank (Jinja, Uganda)</p>
+          <p className="text-muted-foreground">Tank 02 — LPG Bullet Tank (Jinja, Uganda)</p>
         </div>
         
         <div className="space-y-8">


### PR DESCRIPTION
## Summary
- adjust tank specifications and capacity references for Tank 02
- update gauge components to use 2422 mm height and new reference levels
- revise labels across UI to reflect Tank 02

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e33ef088330924c6c361b1a338a