### PR TITLE
feat: add tank2 gauge reference levels

### DIFF
--- a/src/components/HorizontalBulletTank3D.tsx
+++ b/src/components/HorizontalBulletTank3D.tsx
@@ -179,6 +179,24 @@ const HorizontalBulletTank3D = ({
   const currentHeightMm = (heightPercentage / 100) * maxHeight;
   const currentCapacity = getCapacityFromHeight(currentHeightMm, dataObj, maxHeight);
 
+  const referenceLevels = selectedTank === 'tank2'
+    ? [
+        { level: 5, height: 121.1 },
+        { level: 10, height: 242.2 },
+        { level: 85, height: 2058.7 },
+        { level: 90, height: 2179.8 },
+        { level: 95, height: 2300.9 },
+      ]
+    : [
+        { level: 5, height: 154.45 },
+        { level: 10, height: 308.9 },
+        { level: 85, height: 2625.65 },
+        { level: 90, height: 2780.1 },
+        { level: 95, height: 2934.55 },
+      ];
+
+  const displayMaxHeight = selectedTank === 'tank2' ? 2960 : 2955;
+
   return (
     <Card>
       <CardHeader>
@@ -257,12 +275,10 @@ const HorizontalBulletTank3D = ({
           <div className="text-xs text-muted-foreground bg-muted/20 p-2 rounded">
             <div className="font-medium mb-1">Reference Levels:</div>
             <div className="grid grid-cols-2 gap-1">
-              <div>5% → 154.45 mm</div>
-              <div>10% → 308.90 mm</div>
-              <div>85% → 2625.65 mm</div>
-              <div>90% → 2780.1 mm</div>
-              <div>95% → 2934.55 mm</div>
-              <div>Max → 2955 mm</div>
+              {referenceLevels.map(({ level, height }) => (
+                <div key={level}>{level}% → {height} mm</div>
+              ))}
+              <div>Max → {displayMaxHeight} mm</div>
             </div>
           </div>
         </div>

--- a/src/components/TankDescription.tsx
+++ b/src/components/TankDescription.tsx
@@ -25,6 +25,23 @@ const tankSpecifications: Record<'tank1' | 'tank2', { label: string; value: stri
   ],
 };
 
+const referenceLevels: Record<'tank1' | 'tank2', { level: number; height: number }[]> = {
+  tank1: [
+    { level: 5, height: 154.45 },
+    { level: 10, height: 308.9 },
+    { level: 85, height: 2625.65 },
+    { level: 90, height: 2780.1 },
+    { level: 95, height: 2934.55 },
+  ],
+  tank2: [
+    { level: 5, height: 121.1 },
+    { level: 10, height: 242.2 },
+    { level: 85, height: 2058.7 },
+    { level: 90, height: 2179.8 },
+    { level: 95, height: 2300.9 },
+  ],
+};
+
 const TankDescription = ({ selectedTank }: TankDescriptionProps) => {
   const specifications = tankSpecifications[selectedTank];
 
@@ -57,18 +74,25 @@ const TankDescription = ({ selectedTank }: TankDescriptionProps) => {
               The percentage levels below are based on the total calibrated internal height of the tank, and for estimating product volume 
               relative to the tank's fill level during operations, inspections, or inventory management.
             </p>
-            <div className="grid grid-cols-2 gap-2 text-xs">
-              <div className="space-y-1">
-                <div><strong>5%:</strong> 154.45 mm</div>
-                <div><strong>10%:</strong> 308.90 mm</div>
-                <div><strong>85%:</strong> 2625.65 mm</div>
-              </div>
-              <div className="space-y-1">
-                <div><strong>90%:</strong> 2780.1 mm</div>
-                <div><strong>95%:</strong> 2934.55 mm</div>
-                <div><strong>Max:</strong> 2955 mm</div>
-              </div>
-            </div>
+            {(() => {
+              const levels = referenceLevels[selectedTank];
+              const maxHeight = selectedTank === 'tank2' ? 2960 : 2955;
+              return (
+                <div className="grid grid-cols-2 gap-2 text-xs">
+                  <div className="space-y-1">
+                    {levels.slice(0, 3).map(({ level, height }) => (
+                      <div key={level}><strong>{level}%:</strong> {height} mm</div>
+                    ))}
+                  </div>
+                  <div className="space-y-1">
+                    {levels.slice(3).map(({ level, height }) => (
+                      <div key={level}><strong>{level}%:</strong> {height} mm</div>
+                    ))}
+                    <div><strong>Max:</strong> {maxHeight} mm</div>
+                  </div>
+                </div>
+              );
+            })()}
           </div>
           
           <div className="border-t pt-4">


### PR DESCRIPTION
## Summary
- add tank-specific reference levels for 3D horizontal gauge
- show tank2 reference heights in tank description
- support tank2 levels in legacy 3D gauge component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in textarea.tsx, @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a766d9ba808330be9dfac51e4f2b84