### PR TITLE
Remove pressure correction toggle and add VCF table modal

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -39,8 +39,6 @@ interface FormData {
   height: string;
   heightMm: string;
   pressure: string;
-  applyPressureCorrection: boolean;
-  showVCFTable: boolean;
 }
 
 interface CalculatorFormProps {
@@ -66,8 +64,6 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
     height: "0",
     heightMm: "0",
     pressure: "17",
-    applyPressureCorrection: false,
-    showVCFTable: false,
   });
 
   // Pressure correction factors
@@ -95,6 +91,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   const [showShellFactors, setShowShellFactors] = useState(false);
   const [showPressureFactors, setShowPressureFactors] = useState(false);
   const [showHeightCapacity, setShowHeightCapacity] = useState(false);
+  const [showVCFTable, setShowVCFTable] = useState(false);
 
   const handleInputChange = (field: keyof FormData, value: string | boolean) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -144,9 +141,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
       const scf = 1.000000; // Shell correction factor (simplified)
       
       // Calculate corrected volume
-      const correctedVolume = formData.applyPressureCorrection 
-        ? referenceVolume * vcf * pcf * scf
-        : referenceVolume * vcf * scf;
+      const correctedVolume = referenceVolume * vcf * pcf * scf;
       
       // Calculate mass
       const mass = correctedVolume * density;
@@ -173,12 +168,11 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
       height: "0",
       heightMm: "0",
       pressure: "17",
-      applyPressureCorrection: false,
-      showVCFTable: false,
     });
     setResults(null);
     setHeightPercentage(0);
     setCapacity(100);
+    setShowVCFTable(false);
   };
 
   const handleModalOpen = (type: string, open: boolean) => {
@@ -191,6 +185,9 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
         break;
       case 'height':
         setShowHeightCapacity(open);
+        break;
+      case 'vcf':
+        setShowVCFTable(open);
         break;
     }
   };
@@ -268,17 +265,9 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
           <div className="space-y-3">
             <div className="flex items-center space-x-2">
               <Checkbox
-                id="pressureCorrection"
-                checked={formData.applyPressureCorrection}
-                onCheckedChange={(checked) => handleInputChange("applyPressureCorrection", checked as boolean)}
-              />
-              <Label htmlFor="pressureCorrection">Apply Pressure Correction</Label>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
                 id="vcfTable"
-                checked={formData.showVCFTable}
-                onCheckedChange={(checked) => handleInputChange("showVCFTable", checked as boolean)}
+                checked={showVCFTable}
+                onCheckedChange={(checked) => setShowVCFTable(checked as boolean)}
               />
               <Label htmlFor="vcfTable">Show Product Temperature (VCF) table</Label>
             </div>
@@ -363,6 +352,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
         showShellFactors={showShellFactors}
         showPressureFactors={showPressureFactors}
         showHeightCapacity={showHeightCapacity}
+        showVCFTable={showVCFTable}
         onOpenChange={handleModalOpen}
         selectedTank={selectedTank}
       />

--- a/src/components/DataTableModals.tsx
+++ b/src/components/DataTableModals.tsx
@@ -7,6 +7,7 @@ interface DataTableModalsProps {
   showShellFactors: boolean;
   showPressureFactors: boolean;
   showHeightCapacity: boolean;
+  showVCFTable: boolean;
   onOpenChange: (type: string, open: boolean) => void;
   selectedTank: 'tank1' | 'tank2';
 }
@@ -95,7 +96,7 @@ const volumeCorrectionFactors = {
   ]
 };
 
-const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapacity, onOpenChange, selectedTank }: DataTableModalsProps) => {
+const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapacity, showVCFTable, onOpenChange, selectedTank }: DataTableModalsProps) => {
   const dataObj = selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
   const tankData: [number, number][] = Object.entries(dataObj).map(([height, capacity]) => [
     Number(height),
@@ -156,6 +157,40 @@ const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapa
                   <TableRow key={temp}>
                     <TableCell>{temp}</TableCell>
                     <TableCell>{factor.toFixed(6)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Product Temperature (VCF) Table Modal */}
+      <Dialog open={showVCFTable} onOpenChange={(open) => onOpenChange('vcf', open)}>
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-auto">
+          <DialogHeader>
+            <DialogTitle>Product Temperature (VCF) Table</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Volume correction factors based on density and temperature.
+            </p>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Temp (°C)</TableHead>
+                  {volumeCorrectionFactors.densities.map((d) => (
+                    <TableHead key={d}>{d.toFixed(3)}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {volumeCorrectionFactors.temperatures.map((temp, i) => (
+                  <TableRow key={temp}>
+                    <TableCell>{temp.toFixed(1)}</TableCell>
+                    {volumeCorrectionFactors.factors[i].map((factor, j) => (
+                      <TableCell key={j}>{factor.toFixed(3)}</TableCell>
+                    ))}
                   </TableRow>
                 ))}
               </TableBody>


### PR DESCRIPTION
## Summary
- Always apply pressure correction and drop manual toggle
- Add modal displaying product temperature volume correction factors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: “@typescript-eslint/no-empty-object-type” in textarea.tsx, `@typescript-eslint/no-require-imports` in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a76856ae848330a19ea6bb34823324