### PR TITLE
feat: show both tank images

### DIFF
--- a/src/pages/TankView.tsx
+++ b/src/pages/TankView.tsx
@@ -8,11 +8,21 @@ const TankView = () => {
         <div className="relative">
           <img
             src="/tank1.jpg"
-            alt="Tank view"
+            alt="Tank 1 view"
             className="w-full rounded-lg"
           />
           <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
             TANK 1
+          </span>
+        </div>
+        <div className="relative mt-8">
+          <img
+            src="/tank2.jpg"
+            alt="Tank 2 view"
+            className="w-full rounded-lg"
+          />
+          <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
+            TANK 2
           </span>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- display tank2 image beneath tank1 on Tank View page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 11 problems including 3 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a76c2e295c83308e526bc72cc6dafe