### PR TITLE
feat: darken cylindrical tank

### DIFF
--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -65,15 +65,15 @@ const CircularTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         {/* Tank body */}
         <mesh>
           <cylinderGeometry args={[tankRadius, tankRadius, cylinderLength, 32]} />
-          <meshStandardMaterial color="hsl(var(--background))" />
+          <meshStandardMaterial color="#4b5563" />
         </mesh>
         <mesh position={[0, cylinderLength / 2, 0]}>
           <sphereGeometry args={[tankRadius, 32, 32, 0, Math.PI * 2, 0, Math.PI / 2]} />
-          <meshStandardMaterial color="hsl(var(--background))" />
+          <meshStandardMaterial color="#4b5563" />
         </mesh>
         <mesh position={[0, -cylinderLength / 2, 0]} rotation={[Math.PI, 0, 0]}>
           <sphereGeometry args={[tankRadius, 32, 32, 0, Math.PI * 2, 0, Math.PI / 2]} />
-          <meshStandardMaterial color="hsl(var(--background))" />
+          <meshStandardMaterial color="#4b5563" />
         </mesh>
 
         {/* Liquid */}
@@ -98,7 +98,7 @@ const CircularTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         {[-supportOffset, supportOffset].map((y) => (
           <mesh key={y} position={[-tankRadius - 0.3, y, 0]}>
             <boxGeometry args={[0.2, tankRadius * 2, 0.2]} />
-            <meshStandardMaterial color="hsl(var(--background))" />
+            <meshStandardMaterial color="#4b5563" />
           </mesh>
         ))}
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- darken 3D cylindrical tank mesh for better contrast
- replace interface stubs with type aliases to satisfy lint rules
- import tailwindcss-animate via ESM instead of require

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ad315e0883309261ff7132c76f5c