### PR TITLE
Align 3D gauge indicators to calibrated heights

### DIFF
--- a/src/components/HorizontalCylindricalTank3D.tsx
+++ b/src/components/HorizontalCylindricalTank3D.tsx
@@ -37,7 +37,17 @@ const getCapacityFromHeight = (
   return Math.round(lowerCap + (upperCap - lowerCap) * ratio);
 };
 
-const CylindricalTankMesh = ({ fillLevel, capacity }: { fillLevel: number; capacity: number }) => {
+const CylindricalTankMesh = ({
+  fillLevel,
+  capacity,
+  referenceLevels,
+  maxHeightMm,
+}: {
+  fillLevel: number;
+  capacity: number;
+  referenceLevels: { level: number; height: number }[];
+  maxHeightMm: number;
+}) => {
   const tankRef = useRef<Group>(null);
   const liquidRef = useRef<Group>(null);
   const tankRadius = 1.8;
@@ -106,20 +116,21 @@ const CylindricalTankMesh = ({ fillLevel, capacity }: { fillLevel: number; capac
           ))}
 
           {/* Level indicators */}
-          {[5, 10, 85, 90, 95].map((level) => {
-            const indicatorX = -tankHeight / 2 + (level / 100) * tankHeight;
+          {referenceLevels.map(({ level, height }) => {
+            const indicatorX = -tankHeight / 2 + (height / maxHeightMm) * tankHeight;
+            const indicatorLevel = (height / maxHeightMm) * 100;
             return (
               <group key={level}>
                 <mesh position={[indicatorX, -tankTotalLength / 2 - 0.2, 0]}>
                   <boxGeometry args={[0.05, 0.3, 0.05]} />
                   <meshStandardMaterial
-                    color={Math.abs(level - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
+                    color={Math.abs(indicatorLevel - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
                   />
                 </mesh>
                 <mesh position={[indicatorX, tankTotalLength / 2 + 0.2, 0]}>
                   <boxGeometry args={[0.05, 0.3, 0.05]} />
                   <meshStandardMaterial
-                    color={Math.abs(level - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
+                    color={Math.abs(indicatorLevel - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
                   />
                 </mesh>
               </group>
@@ -219,7 +230,12 @@ const HorizontalCylindricalTank3D = ({
             <pointLight position={[10, 10, 10]} intensity={1} />
             <directionalLight position={[-5, 10, 5]} intensity={0.8} />
             <directionalLight position={[5, -5, -5]} intensity={0.3} />
-            <CylindricalTankMesh fillLevel={heightPercentage} capacity={currentCapacity} />
+            <CylindricalTankMesh
+              fillLevel={heightPercentage}
+              capacity={currentCapacity}
+              referenceLevels={referenceLevels}
+              maxHeightMm={maxHeight}
+            />
             <OrbitControls
               enablePan={false}
               enableZoom={true}

--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -37,7 +37,15 @@ const getCapacityFromHeight = (
 };
 
 // Circular tank mesh rendered in the 3D scene
-const CircularTankMesh = ({ fillLevel }: { fillLevel: number }) => {
+const CircularTankMesh = ({
+  fillLevel,
+  referenceLevels,
+  maxHeightMm,
+}: {
+  fillLevel: number;
+  referenceLevels: { level: number; height: number }[];
+  maxHeightMm: number;
+}) => {
   const tankRef = useRef<Group>(null);
   const liquidRef = useRef<Group>(null);
   const tankRadius = 1.8;
@@ -104,17 +112,22 @@ const CircularTankMesh = ({ fillLevel }: { fillLevel: number }) => {
         ))}
 
         {/* Level indicators */}
-        {[5, 10, 85, 90, 95].map((level) => {
-          const indicatorX = -tankHeight / 2 + (level / 100) * tankHeight;
+        {referenceLevels.map(({ level, height }) => {
+          const indicatorX = -tankHeight / 2 + (height / maxHeightMm) * tankHeight;
+          const indicatorLevel = (height / maxHeightMm) * 100;
           return (
             <group key={level}>
               <mesh position={[indicatorX, -tankTotalLength / 2 - 0.2, 0]}>
                 <boxGeometry args={[0.05, 0.3, 0.05]} />
-                <meshStandardMaterial color={Math.abs(level - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'} />
+                <meshStandardMaterial
+                  color={Math.abs(indicatorLevel - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
+                />
               </mesh>
               <mesh position={[indicatorX, tankTotalLength / 2 + 0.2, 0]}>
                 <boxGeometry args={[0.05, 0.3, 0.05]} />
-                <meshStandardMaterial color={Math.abs(level - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'} />
+                <meshStandardMaterial
+                  color={Math.abs(indicatorLevel - fillLevel) < 5 ? '#4ade80' : 'hsl(var(--muted-foreground))'}
+                />
               </mesh>
             </group>
           );
@@ -171,7 +184,11 @@ const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange, selec
             <pointLight position={[10, 10, 10]} intensity={1} />
             <directionalLight position={[-5, 10, 5]} intensity={0.8} />
             <directionalLight position={[5, -5, -5]} intensity={0.3} />
-            <CircularTankMesh fillLevel={heightPercentage} />
+            <CircularTankMesh
+              fillLevel={heightPercentage}
+              referenceLevels={referenceLevels}
+              maxHeightMm={maxHeight}
+            />
             <OrbitControls enablePan={false} enableZoom={true} maxDistance={15} minDistance={5} />
           </Canvas>
         </div>


### PR DESCRIPTION
## Summary
- show tank level markers at calibrated heights for both tanks
- display reference level heights in 3D gauges

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9d4e6e74c83309a83b7f9492293f0