### PR TITLE
Calibrate tank gauges using reference level mappings

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -10,6 +10,11 @@ import { getVolumeCorrectionFactor as getVCFTank1 } from "@/lib/volumeCorrection
 import { getVolumeCorrectionFactor as getVCFTank2 } from "@/lib/volumeCorrectionTank2";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
 import { heightCapacityDataTank2 } from "@/data/tank2HeightCapacity";
+import {
+  getHeightFromPercentage,
+  getPercentageFromHeight,
+  percentageHeightData,
+} from "@/data/percentageHeightMapping";
 
 const getCapacityFromHeight = (
   heightMm: number,
@@ -84,8 +89,12 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   const [heightPercentage, setHeightPercentage] = useState<number>(0);
   const [capacity, setCapacity] = useState<number>(100);
 
-  const heightData = selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
-  const maxHeight = selectedTank === 'tank2' ? 2960 : 2954;
+  const heightData =
+    selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
+  const maxHeight =
+    percentageHeightData[selectedTank][
+      percentageHeightData[selectedTank].length - 1
+    ].height;
   
   // Modal states
   const [showShellFactors, setShowShellFactors] = useState(false);
@@ -100,10 +109,9 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
     if (field === 'heightMm' && typeof value === 'string') {
       const heightMm = parseFloat(value);
       if (!isNaN(heightMm)) {
-        const percentage = (heightMm / maxHeight) * 100; // Convert mm to percentage
+        const percentage = getPercentageFromHeight(heightMm, selectedTank);
         setHeightPercentage(Math.min(100, Math.max(0, percentage)));
 
-        // Also update capacity based on height using interpolation data
         setCapacity(getCapacityFromHeight(heightMm, heightData, maxHeight));
       }
     }
@@ -112,8 +120,8 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   const handleHeightChange = (height: number) => {
     setHeightPercentage(height);
     // Auto-sync height in mm based on percentage
-    const heightMm = (height / 100) * maxHeight; // Max height from tank specifications
-    setFormData(prev => ({ ...prev, heightMm: heightMm.toString() }));
+    const heightMm = getHeightFromPercentage(height, selectedTank);
+    setFormData((prev) => ({ ...prev, heightMm: heightMm.toString() }));
     setCapacity(getCapacityFromHeight(heightMm, heightData, maxHeight));
   };
 

--- a/src/components/HorizontalCylindricalTank3D.tsx
+++ b/src/components/HorizontalCylindricalTank3D.tsx
@@ -7,6 +7,10 @@ import { Slider } from "@/components/ui/slider";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
 import { heightCapacityDataTank2 } from "@/data/tank2HeightCapacity";
+import {
+  getHeightFromPercentage,
+  percentageHeightData,
+} from "@/data/percentageHeightMapping";
 
 interface HorizontalCylindricalTank3DProps {
   heightPercentage: number;
@@ -160,15 +164,18 @@ const HorizontalCylindricalTank3D = ({
   selectedTank,
   onTankChange,
 }: HorizontalCylindricalTank3DProps) => {
-  const dataObj = selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
-  const maxHeight = selectedTank === 'tank2' ? 2960 : 2954;
+  const dataObj =
+    selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
+  const maxHeight =
+    percentageHeightData[selectedTank][
+      percentageHeightData[selectedTank].length - 1
+    ].height;
 
   const handleSliderChange = (value: number[]) => {
     const newPercentage = value[0];
     onHeightChange(newPercentage);
 
-    // Calculate height in mm based on percentage
-    const heightMm = (newPercentage / 100) * maxHeight; // Max height from specifications
+    const heightMm = getHeightFromPercentage(newPercentage, selectedTank);
     const capacity = getCapacityFromHeight(heightMm, dataObj, maxHeight);
     onCapacityChange(capacity);
   };
@@ -178,26 +185,18 @@ const HorizontalCylindricalTank3D = ({
   };
 
   // Calculate current height and capacity
-  const currentHeightMm = (heightPercentage / 100) * maxHeight;
-  const currentCapacity = getCapacityFromHeight(currentHeightMm, dataObj, maxHeight);
+  const currentHeightMm = getHeightFromPercentage(heightPercentage, selectedTank);
+  const currentCapacity = getCapacityFromHeight(
+    currentHeightMm,
+    dataObj,
+    maxHeight
+  );
 
-  const referenceLevels = selectedTank === 'tank2'
-    ? [
-        { level: 5, height: 121.1 },
-        { level: 10, height: 242.2 },
-        { level: 85, height: 2058.7 },
-        { level: 90, height: 2179.8 },
-        { level: 95, height: 2300.9 },
-      ]
-    : [
-        { level: 5, height: 154.45 },
-        { level: 10, height: 308.9 },
-        { level: 85, height: 2625.65 },
-        { level: 90, height: 2780.1 },
-        { level: 95, height: 2934.55 },
-      ];
+  const referenceLevels = percentageHeightData[selectedTank]
+    .filter((p) => p.percentage !== 0 && p.percentage !== 100)
+    .map((p) => ({ level: p.percentage, height: p.height }));
 
-  const displayMaxHeight = selectedTank === 'tank2' ? 2960 : 2955;
+  const displayMaxHeight = maxHeight;
 
   return (
     <Card>

--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -6,6 +6,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
 import { heightCapacityDataTank1 } from '@/components/TankGauge';
 import { heightCapacityDataTank2 } from '@/data/tank2HeightCapacity';
+import {
+  getHeightFromPercentage,
+  percentageHeightData,
+} from '@/data/percentageHeightMapping';
 
 interface Tank3DProps {
   heightPercentage: number;
@@ -138,38 +142,39 @@ const CircularTankMesh = ({
 };
 
 // 3D circular tank gauge component
-const Tank3DGauge = ({ heightPercentage, onHeightChange, onCapacityChange, selectedTank }: Tank3DProps) => {
-  const dataObj = selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
-  const maxHeight = selectedTank === 'tank2' ? 2960 : 2954;
-  const displayMaxHeight = selectedTank === 'tank2' ? 2960 : 2955;
+const Tank3DGauge = ({
+  heightPercentage,
+  onHeightChange,
+  onCapacityChange,
+  selectedTank,
+}: Tank3DProps) => {
+  const dataObj =
+    selectedTank === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
+  const maxHeight =
+    percentageHeightData[selectedTank][
+      percentageHeightData[selectedTank].length - 1
+    ].height;
+  const displayMaxHeight = maxHeight;
 
-  const referenceLevels = selectedTank === 'tank2'
-    ? [
-        { level: 5, height: 121.1 },
-        { level: 10, height: 242.2 },
-        { level: 85, height: 2058.7 },
-        { level: 90, height: 2179.8 },
-        { level: 95, height: 2300.9 },
-      ]
-    : [
-        { level: 5, height: 154.45 },
-        { level: 10, height: 308.9 },
-        { level: 85, height: 2625.65 },
-        { level: 90, height: 2780.1 },
-        { level: 95, height: 2934.55 },
-      ];
+  const referenceLevels = percentageHeightData[selectedTank]
+    .filter((p) => p.percentage !== 0 && p.percentage !== 100)
+    .map((p) => ({ level: p.percentage, height: p.height }));
 
   const handleSliderChange = (value: number[]) => {
     const newPercentage = value[0];
     onHeightChange(newPercentage);
 
-    const heightMm = (newPercentage / 100) * maxHeight; // Max height from specifications
+    const heightMm = getHeightFromPercentage(newPercentage, selectedTank);
     const capacity = getCapacityFromHeight(heightMm, dataObj, maxHeight);
     onCapacityChange(capacity);
   };
 
-  const currentHeightMm = (heightPercentage / 100) * maxHeight;
-  const currentCapacity = getCapacityFromHeight(currentHeightMm, dataObj, maxHeight);
+  const currentHeightMm = getHeightFromPercentage(heightPercentage, selectedTank);
+  const currentCapacity = getCapacityFromHeight(
+    currentHeightMm,
+    dataObj,
+    maxHeight
+  );
 
   return (
     <Card>

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
+import { getHeightFromPercentage, percentageHeightData } from '@/data/percentageHeightMapping';
 
 // Height to capacity mapping based on tank measurements
 // Heights in MM mapped to capacities in L - Total Energies Uganda Tank Data
@@ -305,12 +306,13 @@ export const heightCapacityDataTank1: { [key: number]: number } = {
 };
 
 // Maximum calibrated height of tank in millimeters
-const MAX_HEIGHT_MM = 2954;
+const MAX_HEIGHT_MM =
+  percentageHeightData.tank1[percentageHeightData.tank1.length - 1].height;
 
 // Convert height percentage (0-100) to millimeters and estimate capacity
 // using interpolation between points in the height-capacity chart
 function getCapacityFromPercentage(percentage: number): number {
-  const heightMM = (percentage / 100) * MAX_HEIGHT_MM;
+  const heightMM = getHeightFromPercentage(percentage, 'tank1');
 
   if (heightMM <= 0) return heightCapacityDataTank1[0];
   if (heightMM >= MAX_HEIGHT_MM) return heightCapacityDataTank1[MAX_HEIGHT_MM];

--- a/src/data/percentageHeightMapping.ts
+++ b/src/data/percentageHeightMapping.ts
@@ -1,0 +1,50 @@
+export interface PercentageHeight {
+  percentage: number;
+  height: number;
+}
+
+export const percentageHeightData = {
+  tank1: [
+    { percentage: 0, height: 0 },
+    { percentage: 5, height: 154.45 },
+    { percentage: 10, height: 308.9 },
+    { percentage: 85, height: 2625.65 },
+    { percentage: 90, height: 2780.1 },
+    { percentage: 95, height: 2934.55 },
+    { percentage: 100, height: 2954 },
+  ],
+  tank2: [
+    { percentage: 0, height: 0 },
+    { percentage: 5, height: 121.1 },
+    { percentage: 10, height: 242.2 },
+    { percentage: 85, height: 2058.7 },
+    { percentage: 90, height: 2179.8 },
+    { percentage: 95, height: 2300.9 },
+    { percentage: 100, height: 2960 },
+  ],
+} as const;
+
+type TankId = keyof typeof percentageHeightData;
+
+export const getHeightFromPercentage = (percentage: number, tank: TankId): number => {
+  const data = percentageHeightData[tank];
+  if (percentage <= data[0].percentage) return data[0].height;
+  if (percentage >= data[data.length - 1].percentage) return data[data.length - 1].height;
+  const index = data.findIndex((p) => p.percentage >= percentage);
+  const lower = data[index - 1];
+  const upper = data[index];
+  const ratio =
+    (percentage - lower.percentage) / (upper.percentage - lower.percentage);
+  return lower.height + (upper.height - lower.height) * ratio;
+};
+
+export const getPercentageFromHeight = (height: number, tank: TankId): number => {
+  const data = percentageHeightData[tank];
+  if (height <= data[0].height) return data[0].percentage;
+  if (height >= data[data.length - 1].height) return data[data.length - 1].percentage;
+  const index = data.findIndex((p) => p.height >= height);
+  const lower = data[index - 1];
+  const upper = data[index];
+  const ratio = (height - lower.height) / (upper.height - lower.height);
+  return lower.percentage + (upper.percentage - lower.percentage) * ratio;
+};


### PR DESCRIPTION
## Summary
- add percentage-to-height reference data for both tanks
- interpolate gauge height from new mapping to drive capacity calculations
- update form logic to convert between height and percentage using calibrated values

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9d8f696088330a681a3a9a90efea3