### PR TITLE
refactor: tidy header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,28 +1,27 @@
+import { Link } from "react-router-dom";
 import AboutCalibrationDialog from "./AboutCalibrationDialog";
 import HelpDialog from "./HelpDialog";
-import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 const Header = () => {
   return (
-    <header className="bg-card border-b border-border px-6 py-4">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
-        <div className="flex flex-col items-center gap-1">
+    <header className="bg-card border-b border-border">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
+        <Link to="/" className="flex items-center gap-2">
           <img
             src="/murbanlogo.jpg"
             alt="Murban logo"
             className="w-16 h-16 object-contain rounded"
           />
           <span className="font-bold text-foreground">Murban limited</span>
-        </div>
-        <div className="flex flex-col items-end gap-2">
-          <div className="flex items-center gap-4">
-            <AboutCalibrationDialog />
-            <HelpDialog />
-          </div>
-          <Link to="/tank-view" className="text-sm font-medium text-foreground hover:text-primary">
-            Tank view
-          </Link>
-        </div>
+        </Link>
+        <nav className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/tank-view">Tank view</Link>
+          </Button>
+          <AboutCalibrationDialog />
+          <HelpDialog />
+        </nav>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- streamline header layout and align nav items

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b5e26420832eb3c4e5c63e9371f5