### PR TITLE
Replace 3D tank gauge with 2D visualization

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -4,8 +4,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import HorizontalCylindricalTank3D from "@/components/HorizontalCylindricalTank3D";
+import TankGauge from "@/components/TankGauge";
 import DataTableModals from "@/components/DataTableModals";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { getVolumeCorrectionFactor as getVCFTank1 } from "@/lib/volumeCorrection";
 import { getVolumeCorrectionFactor as getVCFTank2 } from "@/lib/volumeCorrectionTank2";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
@@ -125,8 +126,18 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
     setCapacity(getCapacityFromHeight(heightMm, heightData, maxHeight));
   };
 
-  const handleCapacityChange = (newCapacity: number) => {
-    setCapacity(newCapacity);
+  const handleTankSelection = (value: string) => {
+    if (value) {
+      onTankChange(value as 'tank1' | 'tank2');
+      const heightMm = getHeightFromPercentage(heightPercentage, value as 'tank1' | 'tank2');
+      setFormData((prev) => ({ ...prev, heightMm: heightMm.toString() }));
+      const dataObj = value === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
+      const maxHeightValue =
+        percentageHeightData[value as 'tank1' | 'tank2'][
+          percentageHeightData[value as 'tank1' | 'tank2'].length - 1
+        ].height;
+      setCapacity(getCapacityFromHeight(heightMm, dataObj, maxHeightValue));
+    }
   };
 
   // Volume correction factors (VCF) - using calibration table data
@@ -202,13 +213,25 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-      <HorizontalCylindricalTank3D
-        heightPercentage={heightPercentage}
-        onHeightChange={handleHeightChange}
-        onCapacityChange={handleCapacityChange}
-        selectedTank={selectedTank}
-        onTankChange={onTankChange}
-      />
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Select Tank</label>
+          <ToggleGroup
+            type="single"
+            value={selectedTank}
+            onValueChange={handleTankSelection}
+            className="w-full"
+          >
+            <ToggleGroupItem value="tank1" className="flex-1">Tank One</ToggleGroupItem>
+            <ToggleGroupItem value="tank2" className="flex-1">Tank Two</ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+        <TankGauge
+          heightPercentage={heightPercentage}
+          onHeightChange={handleHeightChange}
+          capacity={capacity}
+        />
+      </div>
       
       <Card>
         <CardHeader>

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
-import { getHeightFromPercentage, percentageHeightData } from '@/data/percentageHeightMapping';
+// getHeightFromPercentage and percentageHeightData were previously used for
+// internal capacity calculations. The gauge now receives capacity from props,
+// so these imports are no longer required.
 
 // Height to capacity mapping based on tank measurements
 // Heights in MM mapped to capacities in L - Total Energies Uganda Tank Data
@@ -305,45 +307,16 @@ export const heightCapacityDataTank1: { [key: number]: number } = {
   2950: 98696, 2951: 98701, 2952: 98706, 2953: 98711, 2954: 98716
 };
 
-// Maximum calibrated height of tank in millimeters
-const MAX_HEIGHT_MM =
-  percentageHeightData.tank1[percentageHeightData.tank1.length - 1].height;
-
-// Convert height percentage (0-100) to millimeters and estimate capacity
-// using interpolation between points in the height-capacity chart
-function getCapacityFromPercentage(percentage: number): number {
-  const heightMM = getHeightFromPercentage(percentage, 'tank1');
-
-  if (heightMM <= 0) return heightCapacityDataTank1[0];
-  if (heightMM >= MAX_HEIGHT_MM) return heightCapacityDataTank1[MAX_HEIGHT_MM];
-
-  const lower = Math.floor(heightMM);
-  const upper = Math.ceil(heightMM);
-  const lowerCap = heightCapacityDataTank1[lower];
-  const upperCap = heightCapacityDataTank1[upper];
-
-  if (lowerCap === undefined || upperCap === undefined) {
-    return heightCapacityDataTank1[lower] || heightCapacityDataTank1[0];
-  }
-
-  const ratio = heightMM - lower;
-  return Math.round(lowerCap + (upperCap - lowerCap) * ratio);
-}
-
 interface TankGaugeProps {
   heightPercentage: number;
+  capacity: number;
   onHeightChange: (height: number) => void;
-  onCapacityChange: (capacity: number) => void;
 }
 
-const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, onHeightChange, onCapacityChange }) => {
-  const capacity = getCapacityFromPercentage(heightPercentage);
-
+const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHeightChange }) => {
   const handleSliderChange = (values: number[]) => {
     const newHeight = values[0];
-    const newCapacity = getCapacityFromPercentage(newHeight);
     onHeightChange(newHeight);
-    onCapacityChange(newCapacity);
   };
 
   // Ensure the displayed fill level remains within valid bounds so the


### PR DESCRIPTION
## Summary
- swap out 3D tank gauge for a simpler 2D gauge
- add tank selection controls in the calculator form
- refactor 2D gauge to accept capacity from parent component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b57d6644832eb6cd6c67ad8bd429