### PR TITLE
Update branding and theme colors

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
             alt="Murban logo"
             className="w-16 h-16 object-contain rounded"
           />
-          <span className="font-bold text-foreground">Murban limited</span>
+          <span className="font-bold text-foreground">Murban Engineering</span>
         </Link>
         <nav className="flex items-center gap-4">
           <Button variant="ghost" size="sm" asChild>

--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,8 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 0 0% 98%;
-    --foreground: 215 25% 27%;
+    --background: 227.6 35.8% 15.9%;
+    --foreground: 203.8 64.2% 52.9%;
 
     --card: 0 0% 100%;
     --card-foreground: 215 25% 27%;
@@ -56,8 +56,8 @@ All colors MUST be HSL.
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 227.6 35.8% 15.9%;
+    --foreground: 203.8 64.2% 52.9%;
 
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;


### PR DESCRIPTION
## Summary
- update header logo text to "Murban Engineering"
- set background to #1A2037 and foreground to #3A97D4 via HSL variables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7e6d5f4832e97637d0fe9ce4f35