### PR TITLE
Reduce header height

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,12 +6,12 @@ import { Button } from "@/components/ui/button";
 const Header = () => {
   return (
     <header className="bg-card border-b border-border">
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-2">
         <Link to="/" className="flex items-center gap-2">
           <img
             src="/murbanlogo.jpg"
             alt="Murban logo"
-            className="w-16 h-16 object-contain rounded"
+            className="w-12 h-12 object-contain rounded"
           />
           <span className="font-bold text-foreground">Murban limited</span>
         </Link>


### PR DESCRIPTION
## Summary
- shorten navigation bar by reducing padding and logo size

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b87d126c832e904e4468fe34106d