### PR TITLE
feat: update tank gauge design

### DIFF
--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -332,8 +332,8 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
         {/* Visual Tank Gauge */}
         <div className="flex justify-center">
           <div className="relative">
-            {/* Tank Outline */}
-            <div className="w-64 h-64 border-4 border-green-500 rounded-full bg-secondary/20 relative overflow-hidden">
+            {/* Tank Outline - Horizontal cylinder with hemispherical ends */}
+            <div className="w-64 h-32 border-4 border-green-500 rounded-full bg-[#FCF7F8] relative overflow-hidden">
               {/* Liquid Level */}
               <div
                 className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-green-400 to-green-200 transition-all duration-300 ease-out"

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,8 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 227.6 35.8% 15.9%;
+    /* Set global background to #FCF7F8 */
+    --background: 348 45% 97.8%;
     --foreground: 203.8 64.2% 52.9%;
 
     --card: 0 0% 100%;
@@ -56,7 +57,8 @@ All colors MUST be HSL.
   }
 
   .dark {
-    --background: 227.6 35.8% 15.9%;
+    /* Match dark mode background to #FCF7F8 */
+    --background: 348 45% 97.8%;
     --foreground: 203.8 64.2% 52.9%;
 
     --card: 222.2 84% 4.9%;


### PR DESCRIPTION
## Summary
- render tank gauge as horizontal cylinder with hemispherical ends
- set app background color to #FCF7F8

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ba09e2a0832e8c5957b34458fc03