### PR TITLE
Move capacity chart to gauge and remove thermal expansion note

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -230,6 +230,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
           heightPercentage={heightPercentage}
           onHeightChange={handleHeightChange}
           capacity={capacity}
+          selectedTank={selectedTank}
         />
       </div>
       

--- a/src/components/TankDescription.tsx
+++ b/src/components/TankDescription.tsx
@@ -25,23 +25,6 @@ const tankSpecifications: Record<'tank1' | 'tank2', { label: string; value: stri
   ],
 };
 
-const referenceLevels: Record<'tank1' | 'tank2', { level: number; height: number }[]> = {
-  tank1: [
-    { level: 5, height: 154.45 },
-    { level: 10, height: 308.9 },
-    { level: 85, height: 2625.65 },
-    { level: 90, height: 2780.1 },
-    { level: 95, height: 2934.55 },
-  ],
-  tank2: [
-    { level: 5, height: 121.1 },
-    { level: 10, height: 242.2 },
-    { level: 85, height: 2058.7 },
-    { level: 90, height: 2179.8 },
-    { level: 95, height: 2300.9 },
-  ],
-};
-
 const TankDescription = ({ selectedTank }: TankDescriptionProps) => {
   const specifications = tankSpecifications[selectedTank];
 
@@ -66,43 +49,6 @@ const TankDescription = ({ selectedTank }: TankDescriptionProps) => {
               )}
             </div>
           ))}
-          
-          <div className="border-t pt-4">
-            <h4 className="font-semibold text-sm mb-3">Capacity Chart Information</h4>
-            <p className="text-xs text-muted-foreground mb-2">
-              This document provides a capacity chart for the tank, showing the corresponding liquid volume in liters based on the liquid height. 
-              The percentage levels below are based on the total calibrated internal height of the tank, and for estimating product volume 
-              relative to the tank's fill level during operations, inspections, or inventory management.
-            </p>
-            {(() => {
-              const levels = referenceLevels[selectedTank];
-              const maxHeight = selectedTank === 'tank2' ? 2960 : 2955;
-              return (
-                <div className="grid grid-cols-2 gap-2 text-xs">
-                  <div className="space-y-1">
-                    {levels.slice(0, 3).map(({ level, height }) => (
-                      <div key={level}><strong>{level}%:</strong> {height} mm</div>
-                    ))}
-                  </div>
-                  <div className="space-y-1">
-                    {levels.slice(3).map(({ level, height }) => (
-                      <div key={level}><strong>{level}%:</strong> {height} mm</div>
-                    ))}
-                    <div><strong>Max:</strong> {maxHeight} mm</div>
-                  </div>
-                </div>
-              );
-            })()}
-          </div>
-          
-          <div className="border-t pt-4">
-            <h4 className="font-semibold text-sm mb-2">Thermal Expansion Coefficients</h4>
-            <p className="text-xs text-muted-foreground">
-              The thermal expansion coefficients indicate the rate of volumetric change of LPG with respect to temperature variations 
-              and are based on the product's density at 20°C. These values are derived from standard industry data and align with 
-              those found in API MPMS Chapter 11.2.4, ASTM D1250, and ISO 91.
-            </p>
-          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
+import { referenceLevels } from '@/data/referenceLevels';
 // getHeightFromPercentage and percentageHeightData were previously used for
 // internal capacity calculations. The gauge now receives capacity from props,
 // so these imports are no longer required.
@@ -311,9 +312,10 @@ interface TankGaugeProps {
   heightPercentage: number;
   capacity: number;
   onHeightChange: (height: number) => void;
+  selectedTank: 'tank1' | 'tank2';
 }
 
-const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHeightChange }) => {
+const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHeightChange, selectedTank }) => {
   const handleSliderChange = (values: number[]) => {
     const newHeight = values[0];
     onHeightChange(newHeight);
@@ -386,6 +388,34 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
             <div className="text-2xl font-bold text-primary">{capacity.toLocaleString()}</div>
             <div className="text-sm text-muted-foreground">Capacity (L)</div>
           </div>
+        </div>
+
+        <div className="border-t pt-4">
+          <h4 className="font-semibold text-sm mb-3">Capacity Chart Information</h4>
+          <p className="text-xs text-muted-foreground mb-2">
+            This document provides a capacity chart for the tank, showing the corresponding liquid volume in liters based on the liquid height.
+            The percentage levels below are based on the total calibrated internal height of the tank, and for estimating product volume
+            relative to the tank's fill level during operations, inspections, or inventory management.
+          </p>
+          {(() => {
+            const levels = referenceLevels[selectedTank];
+            const maxHeight = selectedTank === 'tank2' ? 2960 : 2955;
+            return (
+              <div className="grid grid-cols-2 gap-2 text-xs">
+                <div className="space-y-1">
+                  {levels.slice(0, 3).map(({ level, height }) => (
+                    <div key={level}><strong>{level}%:</strong> {height} mm</div>
+                  ))}
+                </div>
+                <div className="space-y-1">
+                  {levels.slice(3).map(({ level, height }) => (
+                    <div key={level}><strong>{level}%:</strong> {height} mm</div>
+                  ))}
+                  <div><strong>Max:</strong> {maxHeight} mm</div>
+                </div>
+              </div>
+            );
+          })()}
         </div>
       </CardContent>
     </Card>

--- a/src/data/referenceLevels.ts
+++ b/src/data/referenceLevels.ts
@@ -1,0 +1,16 @@
+export const referenceLevels: Record<'tank1' | 'tank2', { level: number; height: number }[]> = {
+  tank1: [
+    { level: 5, height: 154.45 },
+    { level: 10, height: 308.9 },
+    { level: 85, height: 2625.65 },
+    { level: 90, height: 2780.1 },
+    { level: 95, height: 2934.55 },
+  ],
+  tank2: [
+    { level: 5, height: 121.1 },
+    { level: 10, height: 242.2 },
+    { level: 85, height: 2058.7 },
+    { level: 90, height: 2179.8 },
+    { level: 95, height: 2300.9 },
+  ],
+};


### PR DESCRIPTION
## Summary
- show capacity chart info directly within TankGauge and drive it via selected tank
- drop thermal expansion details from TankDescription
- centralize reference level data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b2ba85bd9c832e898b518a99324f63