### PR TITLE
Use slider gauge for tank selection

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import TankGauge from "@/components/TankGauge";
 import DataTableModals from "@/components/DataTableModals";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Slider } from "@/components/ui/slider";
 import { getVolumeCorrectionFactor as getVCFTank1 } from "@/lib/volumeCorrection";
 import { getVolumeCorrectionFactor as getVCFTank2 } from "@/lib/volumeCorrectionTank2";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
@@ -126,18 +126,17 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
     setCapacity(getCapacityFromHeight(heightMm, heightData, maxHeight));
   };
 
-  const handleTankSelection = (value: string) => {
-    if (value) {
-      onTankChange(value as 'tank1' | 'tank2');
-      const heightMm = getHeightFromPercentage(heightPercentage, value as 'tank1' | 'tank2');
-      setFormData((prev) => ({ ...prev, heightMm: heightMm.toString() }));
-      const dataObj = value === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
-      const maxHeightValue =
-        percentageHeightData[value as 'tank1' | 'tank2'][
-          percentageHeightData[value as 'tank1' | 'tank2'].length - 1
-        ].height;
-      setCapacity(getCapacityFromHeight(heightMm, dataObj, maxHeightValue));
-    }
+  const handleTankSelection = (value: number[]) => {
+    const tankValue = value[0] === 1 ? 'tank1' : 'tank2';
+    onTankChange(tankValue);
+    const heightMm = getHeightFromPercentage(heightPercentage, tankValue);
+    setFormData((prev) => ({ ...prev, heightMm: heightMm.toString() }));
+    const dataObj = tankValue === 'tank2' ? heightCapacityDataTank2 : heightCapacityDataTank1;
+    const maxHeightValue =
+      percentageHeightData[tankValue][
+        percentageHeightData[tankValue].length - 1
+      ].height;
+    setCapacity(getCapacityFromHeight(heightMm, dataObj, maxHeightValue));
   };
 
   // Volume correction factors (VCF) - using calibration table data
@@ -216,15 +215,18 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
       <div className="space-y-4">
         <div className="space-y-2">
           <label className="text-sm font-medium">Select Tank</label>
-          <ToggleGroup
-            type="single"
-            value={selectedTank}
+          <Slider
+            value={[selectedTank === 'tank1' ? 1 : 2]}
             onValueChange={handleTankSelection}
+            min={1}
+            max={2}
+            step={1}
             className="w-full"
-          >
-            <ToggleGroupItem value="tank1" className="flex-1">Tank One</ToggleGroupItem>
-            <ToggleGroupItem value="tank2" className="flex-1">Tank Two</ToggleGroupItem>
-          </ToggleGroup>
+          />
+          <div className="flex justify-between text-xs">
+            <span>Tank One</span>
+            <span>Tank Two</span>
+          </div>
         </div>
         <TankGauge
           heightPercentage={heightPercentage}

--- a/src/components/HorizontalCylindricalTank3D.tsx
+++ b/src/components/HorizontalCylindricalTank3D.tsx
@@ -4,7 +4,6 @@ import { OrbitControls, Text } from '@react-three/drei';
 import { Group } from 'three';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
 import { heightCapacityDataTank2 } from "@/data/tank2HeightCapacity";
 import {
@@ -180,8 +179,9 @@ const HorizontalCylindricalTank3D = ({
     onCapacityChange(capacity);
   };
 
-  const handleTankChange = (value: string) => {
-    if (value) onTankChange(value);
+  const handleTankChange = (value: number[]) => {
+    const tankValue = value[0] === 1 ? 'tank1' : 'tank2';
+    onTankChange(tankValue);
   };
 
   // Calculate current height and capacity
@@ -207,19 +207,18 @@ const HorizontalCylindricalTank3D = ({
         {/* Tank selection */}
         <div className="space-y-2">
           <label className="text-sm font-medium">Select Tank</label>
-          <ToggleGroup
-            type="single"
-            value={selectedTank}
+          <Slider
+            value={[selectedTank === 'tank1' ? 1 : 2]}
             onValueChange={handleTankChange}
+            min={1}
+            max={2}
+            step={1}
             className="w-full"
-          >
-            <ToggleGroupItem value="tank1" className="flex-1">
-              Tank One
-            </ToggleGroupItem>
-            <ToggleGroupItem value="tank2" className="flex-1">
-              Tank Two
-            </ToggleGroupItem>
-          </ToggleGroup>
+          />
+          <div className="flex justify-between text-xs">
+            <span>Tank One</span>
+            <span>Tank Two</span>
+          </div>
         </div>
 
         {/* 3D Canvas */}


### PR DESCRIPTION
## Summary
- replace tank selection toggles with slider-based gauge in calculator form
- update 3D cylindrical tank component to use slider for tank selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2baa2eff0832eaa2a3c47f7c7ace0