### PR TITLE
Replace tank selection slider with dropdown

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -6,7 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import TankGauge from "@/components/TankGauge";
 import DataTableModals from "@/components/DataTableModals";
-import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { getVolumeCorrectionFactor as getVCFTank1 } from "@/lib/volumeCorrection";
 import { getVolumeCorrectionFactor as getVCFTank2 } from "@/lib/volumeCorrectionTank2";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
@@ -126,8 +132,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
     setCapacity(getCapacityFromHeight(heightMm, heightData, maxHeight));
   };
 
-  const handleTankSelection = (value: number[]) => {
-    const tankValue = value[0] === 1 ? 'tank1' : 'tank2';
+  const handleTankSelection = (tankValue: 'tank1' | 'tank2') => {
     onTankChange(tankValue);
     const heightMm = getHeightFromPercentage(heightPercentage, tankValue);
     setFormData((prev) => ({ ...prev, heightMm: heightMm.toString() }));
@@ -215,18 +220,15 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
       <div className="space-y-4">
         <div className="space-y-2">
           <label className="text-sm font-medium">Select Tank</label>
-          <Slider
-            value={[selectedTank === 'tank1' ? 1 : 2]}
-            onValueChange={handleTankSelection}
-            min={1}
-            max={2}
-            step={1}
-            className="w-full"
-          />
-          <div className="flex justify-between text-xs">
-            <span>Tank One</span>
-            <span>Tank Two</span>
-          </div>
+          <Select value={selectedTank} onValueChange={handleTankSelection}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Choose tank" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="tank1">Tank One</SelectItem>
+              <SelectItem value="tank2">Tank Two</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <TankGauge
           heightPercentage={heightPercentage}

--- a/src/components/HorizontalCylindricalTank3D.tsx
+++ b/src/components/HorizontalCylindricalTank3D.tsx
@@ -4,6 +4,13 @@ import { OrbitControls, Text } from '@react-three/drei';
 import { Group } from 'three';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { heightCapacityDataTank1 } from "@/components/TankGauge";
 import { heightCapacityDataTank2 } from "@/data/tank2HeightCapacity";
 import {
@@ -179,8 +186,7 @@ const HorizontalCylindricalTank3D = ({
     onCapacityChange(capacity);
   };
 
-  const handleTankChange = (value: number[]) => {
-    const tankValue = value[0] === 1 ? 'tank1' : 'tank2';
+  const handleTankChange = (tankValue: 'tank1' | 'tank2') => {
     onTankChange(tankValue);
   };
 
@@ -207,18 +213,15 @@ const HorizontalCylindricalTank3D = ({
         {/* Tank selection */}
         <div className="space-y-2">
           <label className="text-sm font-medium">Select Tank</label>
-          <Slider
-            value={[selectedTank === 'tank1' ? 1 : 2]}
-            onValueChange={handleTankChange}
-            min={1}
-            max={2}
-            step={1}
-            className="w-full"
-          />
-          <div className="flex justify-between text-xs">
-            <span>Tank One</span>
-            <span>Tank Two</span>
-          </div>
+          <Select value={selectedTank} onValueChange={handleTankChange}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Choose tank" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="tank1">Tank One</SelectItem>
+              <SelectItem value="tank2">Tank Two</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         {/* 3D Canvas */}


### PR DESCRIPTION
## Summary
- Swap tank selection slider for dropdown in calculator form and 3D gauge components
- Update handlers to accept string values for selected tank

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc402ab8832e8ef8082ef90ba2a8