### PR TITLE
feat: update theme colors

### DIFF
--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -335,7 +335,7 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
         <div className="flex justify-center">
           <div className="relative">
             {/* Tank Outline - Horizontal cylinder with hemispherical ends */}
-            <div className="w-64 h-32 border-4 border-green-500 rounded-full bg-[#FCF7F8] relative overflow-hidden">
+            <div className="w-64 h-32 border-4 border-green-500 rounded-full bg-background relative overflow-hidden">
               {/* Liquid Level */}
               <div
                 className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-green-400 to-green-200 transition-all duration-300 ease-out"

--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,8 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    /* Set global background to #FCF7F8 */
-    --background: 348 45% 97.8%;
+    /* Set global background to #1A2037 */
+    --background: 227.6 35.8% 15.9%;
     --foreground: 203.8 64.2% 52.9%;
 
     --card: 0 0% 100%;
@@ -57,8 +57,8 @@ All colors MUST be HSL.
   }
 
   .dark {
-    /* Match dark mode background to #FCF7F8 */
-    --background: 348 45% 97.8%;
+    /* Match dark mode background to #1A2037 */
+    --background: 227.6 35.8% 15.9%;
     --foreground: 203.8 64.2% 52.9%;
 
     --card: 222.2 84% 4.9%;


### PR DESCRIPTION
## Summary
- switch global background to #1A2037 and keep foreground #3A97D4
- align TankGauge component with background color variable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd3feb14832eba0f315b962fdf45