### PR TITLE
Fix tank two owner label

### DIFF
--- a/src/components/DataTableModals.tsx
+++ b/src/components/DataTableModals.tsx
@@ -40,7 +40,7 @@ const tankDetails: Record<'tank1' | 'tank2', { label: string; value: string }[]>
   ],
   tank2: [
     { label: "Tank", value: "Tank 02" },
-    { label: "Tank Owner", value: "Total Energies Jinja." },
+    { label: "Tank Owner", value: "Total Energies Uganda" },
     { label: "Location", value: "Jinja, Uganda" },
     { label: "Tank Description", value: "LPG Bullet Tank" },
     { label: "Nominal Diameter", value: "2422 mm" },

--- a/src/components/TankDescription.tsx
+++ b/src/components/TankDescription.tsx
@@ -16,7 +16,7 @@ const tankSpecifications: Record<'tank1' | 'tank2', { label: string; value: stri
   ],
   tank2: [
     { label: "Tank", value: "Tank 02", label2: "Date of Calibration", value2: "29/06/2025" },
-    { label: "Tank Owner", value: "Total Energies Jinja.", label2: "Validity", value2: "10 Years" },
+    { label: "Tank Owner", value: "Total Energies Uganda", label2: "Validity", value2: "10 Years" },
     { label: "Location", value: "Jinja, Uganda", label2: "Overall Uncertainty", value2: "+0.012%" },
     { label: "Tank Description", value: "LPG Bullet Tank", label2: "Method of Calibration", value2: "API MPMS CHAPTER 2" },
     { label: "Nominal Diameter", value: "2422 mm", label2: "Tank calibrated by", value2: "Murban Engineering Limited" },

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,7 @@ const Index = () => {
       <main className="max-w-7xl mx-auto px-6 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground mb-2">
-            {selectedTank === "tank1" ? "Total Energies Uganda" : "Total Energies Jinja."}
+            {selectedTank === "tank1" ? "Total Energies Uganda" : "Total Energies Uganda"}
           </h1>
           <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
           <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- ensure tank 02 shows "Total Energies Uganda" instead of "Total Energies Jinja"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c0039cfc832e99a8ddd1c337c92f