### PR TITLE
Display tank images side by side without stretching

### DIFF
--- a/src/pages/TankView.tsx
+++ b/src/pages/TankView.tsx
@@ -5,25 +5,27 @@ const TankView = () => {
     <div className="min-h-screen bg-background">
       <Header />
       <main className="max-w-7xl mx-auto px-6 py-8">
-        <div className="relative">
-          <img
-            src="/tank1.jpg"
-            alt="Tank 1 view"
-            className="w-full rounded-lg"
-          />
-          <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
-            TANK 1
-          </span>
-        </div>
-        <div className="relative mt-8">
-          <img
-            src="/tank2.jpg"
-            alt="Tank 2 view"
-            className="w-full rounded-lg"
-          />
-          <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
-            TANK 2
-          </span>
+        <div className="grid grid-cols-2 gap-8">
+          <div className="relative">
+            <img
+              src="/tank1.jpg"
+              alt="Tank 1 view"
+              className="w-full h-auto rounded-lg object-contain"
+            />
+            <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
+              TANK 1
+            </span>
+          </div>
+          <div className="relative">
+            <img
+              src="/tank2.jpg"
+              alt="Tank 2 view"
+              className="w-full h-auto rounded-lg object-contain"
+            />
+            <span className="absolute top-2 left-2 bg-white px-2 py-1 rounded shadow text-sm font-medium">
+              TANK 2
+            </span>
+          </div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Arrange tank images in a two-column grid
- Prevent tank images from stretching by keeping their aspect ratio

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c1e69c6c832e825354ac0c962005