### PR TITLE
style: add borders to manual input buttons

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -311,15 +311,15 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
           </div>
 
           <div className="flex flex-wrap gap-2 pt-4">
-            <Button onClick={handleCalculate}>Calculate</Button>
+            <Button variant="outline" onClick={handleCalculate}>Calculate</Button>
             <Button variant="outline" onClick={handleReset}>Reset</Button>
-            <Button variant="outline" size="sm" onClick={() => setShowShellFactors(true)}>
+            <Button variant="outline" onClick={() => setShowShellFactors(true)}>
               Shell Correction Factors
             </Button>
-            <Button variant="outline" size="sm" onClick={() => setShowPressureFactors(true)}>
+            <Button variant="outline" onClick={() => setShowPressureFactors(true)}>
               Pressure Factors
             </Button>
-            <Button variant="outline" size="sm" onClick={() => setShowHeightCapacity(true)}>
+            <Button variant="outline" onClick={() => setShowHeightCapacity(true)}>
               Height↔Capacity Table
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- ensure manual input action buttons use outline variant for visible borders
- remove small sizing so buttons display clearly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c52aa294832eabeb46dac88334c8