### PR TITLE
style: update mass calculator background color

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -219,7 +219,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <div className="rounded-xl bg-gradient-to-r from-red-600 via-red-500 to-blue-600 p-6 text-white space-y-4">
+        <div className="rounded-xl bg-[hsl(228,36%,16%)] p-6 text-white space-y-4">
           <h2 className="text-xl font-semibold">Mass Calculator</h2>
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
- switch mass calculator header background to hsl(228,36%,16%)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c8aaa0bc832e854c1008c7367b99