### PR TITLE
feat: update mass calculator background

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -219,7 +219,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <div className="rounded-xl bg-[hsl(228,36%,16%)] p-6 text-white space-y-4">
+        <div className="rounded-xl bg-green-100 p-6 text-green-900 space-y-4">
           <h2 className="text-xl font-semibold">Mass Calculator</h2>
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
- use light green background and dark text for Mass Calculator card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ca1e9f18832e80817d299bc49594