### PR TITLE
chore: set Mass Calculator background to light grey

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -219,7 +219,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <div className="rounded-xl bg-green-100 p-6 text-green-900 space-y-4">
+        <div className="rounded-xl bg-gray-100 p-6 text-gray-900 space-y-4">
           <h2 className="text-xl font-semibold">Mass Calculator</h2>
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
- set Mass Calculator background to light grey for a neutral look

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2cbc33b90832e9331e083d53da260