### PR TITLE
Use black text for mass calculator

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -219,20 +219,20 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <div className="rounded-xl bg-gray-100 p-6 text-gray-900 space-y-4">
-          <h2 className="text-xl font-semibold">Mass Calculator</h2>
+        <div className="rounded-xl bg-gray-100 p-6 text-black space-y-4">
+          <h2 className="text-xl font-semibold text-black">Mass Calculator</h2>
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Cylinder className="h-4 w-4" />
               <span>Select Tank</span>
             </div>
             <Select value={selectedTank} onValueChange={handleTankSelection}>
-              <SelectTrigger className="w-full bg-white/20 text-white border-none focus:ring-0 focus:ring-offset-0">
+            <SelectTrigger className="w-full bg-white/20 text-black border-none focus:ring-0 focus:ring-offset-0">
                 <SelectValue placeholder="Choose tank" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="tank1">Tank One</SelectItem>
-                <SelectItem value="tank2">Tank Two</SelectItem>
+                <SelectItem value="tank1" className="text-black">Tank One</SelectItem>
+                <SelectItem value="tank2" className="text-black">Tank Two</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -369,7 +369,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
               <div className="pt-2 border-t">
                 <div className="flex justify-between items-center">
                   <span className="text-lg font-semibold">Mass (kg)</span>
-                  <span className="text-xl font-bold text-primary">{results.mass.toFixed(3)}</span>
+                  <span className="text-xl font-bold text-black">{results.mass.toFixed(3)}</span>
                 </div>
               </div>
               <div className="flex gap-2 pt-4">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,7 +14,7 @@ const Index = () => {
           <h1 className="text-3xl font-bold text-foreground mb-2">
             {selectedTank === "tank1" ? "Total Energies Uganda" : "Total Energies Uganda"}
           </h1>
-          <h2 className="text-2xl font-semibold text-primary mb-1">Tank Mass Calculator</h2>
+          <h2 className="text-2xl font-semibold text-black mb-1">Tank Mass Calculator</h2>
           <p className="text-muted-foreground">
             {selectedTank === "tank1"
               ? "Tank 01 — LPG Bullet Tank (Jinja, Uganda)"


### PR DESCRIPTION
## Summary
- ensure Tank Mass Calculator header uses black text
- force black text in Mass Calculator UI and tank selector so Tank One and Tank Two are visible

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2cde9b070832eb5b56efe71b84f1a