### PR TITLE
Improve UI responsiveness across devices

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -251,7 +251,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
             <CardTitle>Manual Inputs</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="productDensity">Product Density (kg/L)</Label>
               <Input
@@ -273,7 +273,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="shellTemperature">Shell Temperature (°C)</Label>
               <Input
@@ -294,7 +294,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="pressure">Pressure (bar)</Label>
               <Input
@@ -340,7 +340,7 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
         <CardContent>
           {results && typeof results === 'object' ? (
             <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-4 text-sm">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Reference Volume (L)</span>
                   <span className="font-medium">{results.referenceVolume.toFixed(3)}</span>

--- a/src/components/DataTableModals.tsx
+++ b/src/components/DataTableModals.tsx
@@ -240,7 +240,7 @@ const DataTableModals = ({ showShellFactors, showPressureFactors, showHeightCapa
             <DialogTitle>Height ↔ Capacity Table</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4 text-sm">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
               {description.map((item, index) => (
                 <div key={index}>
                   <strong>{item.label}:</strong> {item.value}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,11 +2,13 @@ import { Link } from "react-router-dom";
 import AboutCalibrationDialog from "./AboutCalibrationDialog";
 import HelpDialog from "./HelpDialog";
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetTrigger, SheetContent } from "@/components/ui/sheet";
+import { Menu } from "lucide-react";
 
 const Header = () => {
   return (
     <header className="bg-card border-b border-border">
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-2">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 sm:px-6 py-2">
         <Link to="/" className="flex items-center gap-2">
           <img
             src="/murbanlogo.jpg"
@@ -15,13 +17,32 @@ const Header = () => {
           />
           <span className="font-bold text-foreground">Murban Engineering</span>
         </Link>
-        <nav className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" asChild>
-            <Link to="/tank-view">Tank view</Link>
-          </Button>
-          <AboutCalibrationDialog />
-          <HelpDialog />
-        </nav>
+        <div className="flex items-center gap-2">
+          <nav className="hidden sm:flex items-center gap-4">
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/tank-view">Tank view</Link>
+            </Button>
+            <AboutCalibrationDialog />
+            <HelpDialog />
+          </nav>
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" className="sm:hidden">
+                <Menu className="h-6 w-6" />
+                <span className="sr-only">Toggle menu</span>
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left">
+              <nav className="flex flex-col gap-4 mt-6">
+                <Button variant="ghost" asChild>
+                  <Link to="/tank-view">Tank view</Link>
+                </Button>
+                <AboutCalibrationDialog />
+                <HelpDialog />
+              </nav>
+            </SheetContent>
+          </Sheet>
+        </div>
       </div>
     </header>
   );

--- a/src/components/HorizontalCylindricalTank3D.tsx
+++ b/src/components/HorizontalCylindricalTank3D.tsx
@@ -260,7 +260,7 @@ const HorizontalCylindricalTank3D = ({
           </div>
 
           {/* Display current values */}
-          <div className="grid grid-cols-2 gap-4 text-sm bg-muted/30 p-3 rounded-lg">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm bg-muted/30 p-3 rounded-lg">
             <div>
               <span className="font-medium text-muted-foreground">Fill Level:</span>
               <div className="text-lg font-semibold text-primary">{heightPercentage.toFixed(1)}%</div>
@@ -282,7 +282,7 @@ const HorizontalCylindricalTank3D = ({
           {/* Key level indicators */}
           <div className="text-xs text-muted-foreground bg-muted/20 p-2 rounded">
             <div className="font-medium mb-1">Reference Levels:</div>
-            <div className="grid grid-cols-2 gap-1">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
               {referenceLevels.map(({ level, height }) => (
                 <div key={level}>{level}% → {height} mm</div>
               ))}

--- a/src/components/Tank3DGauge.tsx
+++ b/src/components/Tank3DGauge.tsx
@@ -237,7 +237,7 @@ const Tank3DGauge = ({
           </div>
 
           {/* Display current values */}
-          <div className="grid grid-cols-2 gap-4 text-sm bg-muted/30 p-3 rounded-lg">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm bg-muted/30 p-3 rounded-lg">
             <div>
               <span className="font-medium text-muted-foreground">Fill Level:</span>
               <div className="text-lg font-semibold text-primary">{heightPercentage.toFixed(1)}%</div>
@@ -259,7 +259,7 @@ const Tank3DGauge = ({
           {/* Key level indicators */}
           <div className="text-xs text-muted-foreground bg-muted/20 p-2 rounded">
             <div className="font-medium mb-1">Reference Levels:</div>
-            <div className="grid grid-cols-2 gap-1">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
               {referenceLevels.map(({ level, height }) => (
                 <div key={level}>{level}% → {height} mm</div>
               ))}

--- a/src/components/TankGauge.tsx
+++ b/src/components/TankGauge.tsx
@@ -335,7 +335,7 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
         <div className="flex justify-center">
           <div className="relative">
             {/* Tank body */}
-            <div className="w-96 h-24 bg-gradient-to-b from-gray-200 to-gray-300 rounded-full relative overflow-hidden">
+            <div className="w-full max-w-md h-24 bg-gradient-to-b from-gray-200 to-gray-300 rounded-full relative overflow-hidden">
               {/* Liquid Level */}
               <div
                 className="absolute bottom-0 left-0 right-0 bg-green-500 transition-all duration-300 ease-out"
@@ -384,7 +384,7 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
         </div>
 
         {/* Display Values */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="text-center p-4 bg-secondary/20 rounded-lg border">
             <div className="text-2xl font-bold text-primary">{heightPercentage}%</div>
             <div className="text-sm text-muted-foreground">Height</div>
@@ -401,7 +401,7 @@ const TankGauge: React.FC<TankGaugeProps> = ({ heightPercentage, capacity, onHei
             const levels = referenceLevels[selectedTank];
             const maxHeight = selectedTank === 'tank2' ? 2960 : 2955;
             return (
-              <div className="grid grid-cols-2 gap-2 text-xs">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
                 <div className="space-y-1">
                   {levels.slice(0, 3).map(({ level, height }) => (
                     <div key={level}><strong>{level}%:</strong> {height} mm</div>


### PR DESCRIPTION
## Summary
- add mobile sheet navigation to header
- make form layouts responsive on small screens
- scale tank gauge components for mobile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2cebc3470832e97568dccdcf96cb8