### PR TITLE
feat: update tank selection styling

### DIFF
--- a/src/components/CalculatorForm.tsx
+++ b/src/components/CalculatorForm.tsx
@@ -227,28 +227,28 @@ const CalculatorForm = ({ selectedTank, onTankChange }: CalculatorFormProps) => 
               <span>Select Tank</span>
             </div>
             <Select value={selectedTank} onValueChange={handleTankSelection}>
-              <SelectTrigger
+                <SelectTrigger
                 className={`w-full bg-white/20 focus:ring-0 focus:ring-offset-0 ${
                   selectedTank === 'tank1'
-                    ? 'border-2 border-gray-800 text-green-600 font-semibold'
-                    : 'border-none text-black'
+                    ? 'border-2 border-green-600 text-green-600 font-semibold'
+                    : 'border-none text-green-600'
                 }`}
-              >
-                <SelectValue placeholder="Choose tank" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem
-                  value="tank1"
-                  className="text-green-600 font-semibold border-2 border-gray-800"
                 >
-                  Tank One
-                </SelectItem>
-                <SelectItem value="tank2" className="text-black">
-                  Tank Two
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+                  <SelectValue placeholder="Choose tank" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    value="tank1"
+                    className="text-green-600 font-semibold border-2 border-green-600"
+                  >
+                    Tank One
+                  </SelectItem>
+                  <SelectItem value="tank2" className="text-green-600">
+                    Tank Two
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
         </div>
         <TankGauge
           heightPercentage={heightPercentage}


### PR DESCRIPTION
## Summary
- style tank selector with green border when Tank One is chosen
- color Tank Two option text green for consistent visuals

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49795be50832e92635018feec2315